### PR TITLE
SOLR-41: Added basic conversion for URLs.

### DIFF
--- a/sir/wscompat/convert.py
+++ b/sir/wscompat/convert.py
@@ -917,10 +917,11 @@ def convert_standalone_tag(obj):
 
 def convert_url(obj):
     """
-    :type obj: :class'mbdata_models.URL'
+    :type obj: :class`mbdata_models.URL`
     """
-    url = models.url()
-
+    url = models.url(id=obj.gid, resource=obj.url)
+    # obj does not seem to have any links set, so we can't include any
+    # relation lists at this time
     return url
 
 


### PR DESCRIPTION
The incoming data does not seem to include any links, so we cannot currently build any relation lists.
But then the solr documents also don't have the relationtype, targetid or targettype fields yet, so I guess that's to be expected.