### PR TITLE
SOLR-17: Remove tag count due to buggy JSON output

### DIFF
--- a/sir/wscompat/convert.py
+++ b/sir/wscompat/convert.py
@@ -563,7 +563,7 @@ def convert_tag_list(obj):
     """
     :type obj: :class:`[mbdata.models.ArtistTag]`
     """
-    tag_list = models.tag_list(count=len(obj))
+    tag_list = models.tag_list()
     [tag_list.add_tag(convert_tag(t)) for t in obj]
     return tag_list
 


### PR DESCRIPTION
Example - 

The XML output (see tag list)
http://35.193.119.46:8983/solr/artist/select?&q=artist:Beatsteaks&wt=mbxml
The Json output
http://35.193.119.46:8983/solr/artist/select?&q=artist:Beatsteaks&wt=mbjson

How it is currently - 
http://musicbrainz.org/ws/2/artist/?query=artist:Beatsteaks
http://musicbrainz.org/ws/2/artist/?fmt=json&query=artist:Beatsteaks