### PR TITLE
Fix live indexing selections

### DIFF
--- a/sir/amqp/handler.py
+++ b/sir/amqp/handler.py
@@ -4,7 +4,7 @@
 # License: MIT, see LICENSE for details
 from sir.amqp import message
 from sir import get_sentry, config
-from sir.schema import SCHEMA, generate_update_map, generate_model_map
+from sir.schema import SCHEMA, generate_update_map
 from sir.indexing import send_data_to_solr
 from sir.trigger_generation.paths import generate_selection, second_last_model_in_path
 from sir.util import (create_amqp_connection,
@@ -26,8 +26,8 @@ __all__ = ["callback_wrapper", "watch", "Handler"]
 
 logger = getLogger("sir")
 
-update_map = generate_update_map()
-model_map = generate_model_map()
+update_map, model_map = generate_update_map()
+
 #: The number of times we'll try to process a message.
 _DEFAULT_MB_RETRIES = 4
 

--- a/sir/amqp/handler.py
+++ b/sir/amqp/handler.py
@@ -182,6 +182,7 @@ class Handler(object):
                     # need to return PKs since we have them in the message.
                     logger.debug("Generating SELECT statement for %s with path '%s'" % (entity.model, path))
                     select_sql, pk_col_name = generate_selection(entity.model, path)
+                    logger.debug("SQL: %s PK: %s" % (select_sql, pk_col_name))
                     if select_sql is None:
                         # See generate_selection function implementation for cases when `select_sql`
                         # value might be None.
@@ -228,6 +229,7 @@ class Handler(object):
 
                         logger.debug("Generating SELECT statement for %s with path '%s'" % (entity.model, path))
                         select_sql, pk_col_name = generate_selection(entity.model, path)
+                        logger.debug("SQL: %s PK: %s" % (select_sql, pk_col_name))
                         if select_sql is None:
                             # See generate_selection function implementation for cases when `select_sql`
                             # value might be None.

--- a/sir/schema/__init__.py
+++ b/sir/schema/__init__.py
@@ -28,7 +28,6 @@ from sir.schema import queryext
 from sir.schema import modelext
 from sir.schema import transformfuncs as tfs
 from sir.schema.searchentities import SearchEntity as E, SearchField as F
-from sir.trigger_generation.paths import unique_split_paths, last_model_in_path
 from sir.wscompat import convert
 from collections import OrderedDict
 from mbdata import models
@@ -587,6 +586,8 @@ def generate_update_map():
 
     :rtype dict
     """
+    from sir.trigger_generation.paths import unique_split_paths, last_model_in_path
+
     tables = defaultdict(set)
     for core_name, entity in SCHEMA.items():
         # Entity itself:
@@ -594,7 +595,7 @@ def generate_update_map():
         tables[class_mapper(entity.model).mapped_table.name].add((core_name, None))
         # Related tables:
         for path in unique_split_paths([path for field in entity.fields
-                                        for path in field.paths]):
+                                        for path in field.paths] + [path for path in entity.extrapaths or []]):
             model = last_model_in_path(entity.model, path)
             if model is not None:
                 tables[class_mapper(model).mapped_table.name].add((core_name, path))
@@ -607,6 +608,8 @@ def generate_model_map():
 
     :rtype dict
     """
+    from sir.trigger_generation.paths import unique_split_paths, last_model_in_path
+
     tables = dict()
     for core_name, entity in SCHEMA.items():
         # Entity itself:
@@ -614,7 +617,7 @@ def generate_model_map():
         tables[class_mapper(entity.model).mapped_table.name] = entity.model
         # Related tables:
         for path in unique_split_paths([path for field in entity.fields
-                                        for path in field.paths]):
+                                        for path in field.paths] + [path for path in entity.extrapaths or []]):
             model = last_model_in_path(entity.model, path)
             if model is not None:
                 name = class_mapper(model).mapped_table.name

--- a/sir/schema/__init__.py
+++ b/sir/schema/__init__.py
@@ -599,3 +599,25 @@ def generate_update_map():
             if model is not None:
                 tables[class_mapper(model).mapped_table.name].add((core_name, path))
     return dict(tables)
+
+
+def generate_model_map():
+    """
+    Generates mapping from table names to SQLAlchemy ORM models.
+
+    :rtype dict
+    """
+    tables = dict()
+    for core_name, entity in SCHEMA.items():
+        # Entity itself:
+        # TODO(roman): See if the line below is necessary, if there is a better way to implement this.
+        tables[class_mapper(entity.model).mapped_table.name] = entity.model
+        # Related tables:
+        for path in unique_split_paths([path for field in entity.fields
+                                        for path in field.paths]):
+            model = last_model_in_path(entity.model, path)
+            if model is not None:
+                name = class_mapper(model).mapped_table.name
+                if name not in tables:
+                    tables[name] = model
+    return dict(tables)

--- a/sir/trigger_generation/__init__.py
+++ b/sir/trigger_generation/__init__.py
@@ -110,7 +110,7 @@ def write_triggers(trigger_file, function_file, model, is_direct, has_gid, **gen
             delete_trigger_generator = sql_generator.DeleteTriggerGenerator
     else:
         delete_trigger_generator = sql_generator.ReferencedDeleteTriggerGenerator
-        fk_columns = [fk.parent.name for fk in model.__table__.foreign_keys]
+        fk_columns = [r.key for r in mapper.relationships if r.direction.name == 'MANYTOONE']
     write_triggers_to_file(
         trigger_file=trigger_file,
         function_file=function_file,

--- a/sir/trigger_generation/__init__.py
+++ b/sir/trigger_generation/__init__.py
@@ -102,7 +102,7 @@ def write_triggers(trigger_file, function_file, model, is_direct, has_gid, **gen
     # Mapper defines correlation of model class attributes to database table columns
     mapper = class_mapper(model)
     table_name = mapper.mapped_table.name
-
+    fk_columns = []
     if is_direct:
         if has_gid:
             delete_trigger_generator = sql_generator.GIDDeleteTriggerGenerator
@@ -110,7 +110,7 @@ def write_triggers(trigger_file, function_file, model, is_direct, has_gid, **gen
             delete_trigger_generator = sql_generator.DeleteTriggerGenerator
     else:
         delete_trigger_generator = sql_generator.ReferencedDeleteTriggerGenerator
-
+        fk_columns = [fk.parent.name for fk in model.__table__.foreign_keys]
     write_triggers_to_file(
         trigger_file=trigger_file,
         function_file=function_file,
@@ -121,6 +121,7 @@ def write_triggers(trigger_file, function_file, model, is_direct, has_gid, **gen
         ],
         table_name=table_name,
         pk_columns=[pk.name for pk in mapper.primary_key],
+        fk_columns=fk_columns,
         **generator_args
     )
 

--- a/sir/trigger_generation/paths.py
+++ b/sir/trigger_generation/paths.py
@@ -153,13 +153,8 @@ def generate_selection(base_entity_model, path):
                 # FIXME(roman): What if PK consists of multiple rows?
                 pk = mapper.primary_key[0].name
                 last_pk_name = pk
-                if path_elem_n == path_length:
-                    # FIXME(michael): Why does ColumnPathPart take parameters
-                    # if it only renders ":ids"?
-                    new_path_part = ColumnPathPart("", "")
-                else:
-                    table_name = mapper.mapped_table.name
-                    new_path_part = ManyToOnePathPart(table_name, pk, fk_name=column.key)
+                table_name = mapper.mapped_table.name
+                new_path_part = ManyToOnePathPart(table_name, pk, fk_name=column.key)
 
             elif prop.direction == ONETOMANY:
                 remote_side = list(prop.remote_side)[0]

--- a/sir/trigger_generation/paths.py
+++ b/sir/trigger_generation/paths.py
@@ -237,3 +237,14 @@ def last_model_in_path(model, path):
             return None
 
     return current_model
+
+
+def second_last_model_in_path(model, path):
+    if path is None:
+        return (None, None)
+    current_model = model
+    new_path = ".".join(path.split(".")[:-1])
+    if new_path == "":
+        return (current_model, "")
+    else:
+        return (last_model_in_path(model, new_path), new_path)

--- a/sir/trigger_generation/paths.py
+++ b/sir/trigger_generation/paths.py
@@ -240,6 +240,21 @@ def last_model_in_path(model, path):
 
 
 def second_last_model_in_path(model, path):
+    """
+    Walk ``path`` beginning at ``model`` and return the second last model
+    in the path.
+
+    We generate SQL queries with the second last model in path, to determine
+    rows that need to be updated when an entity is deleted. Since those rows
+    will be related to the deleted entity by a foreign key.
+
+    Example: If `area_alias` if deleted, `place` needs to be updated via the path
+    `area.aliases`. We can determine the ids of `place` table that need to be udpated,
+    by determining the `area` rows that were affected by the `area_alias` delete.
+
+    :param model: A :ref:`declarative <sqla:declarative_toplevel>` class.
+    :param str path: The path itself.
+    """
     if path is None:
         return (None, None)
     current_model = model

--- a/sir/trigger_generation/sql_generator.py
+++ b/sir/trigger_generation/sql_generator.py
@@ -99,7 +99,8 @@ class TriggerGenerator(object):
     def message(self):
         return """
             WITH keys({column_keys}) AS ({select})
-            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{{{table_name_key}}}', '"{table_name}"'), '{{{operation_type}}}', '"{operation}"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{{{table_name_key}}}', '"{table_name}"'),
+                             '{{{operation_type}}}', '"{operation}"')::text FROM keys
         """.format(
                 table_name=self.table_name,
                 column_keys=", ".join(self.reference_columns),

--- a/sir/trigger_generation/sql_generator.py
+++ b/sir/trigger_generation/sql_generator.py
@@ -3,6 +3,7 @@
 import textwrap
 
 MSG_JSON_TABLE_NAME_KEY = "_table"
+MSG_JSON_OPERATION_TYPE = "_operation"
 
 
 class TriggerGenerator(object):
@@ -98,12 +99,14 @@ class TriggerGenerator(object):
     def message(self):
         return """
             WITH keys({column_keys}) AS ({select})
-            SELECT jsonb_set(to_jsonb(keys), '{{{table_name_key}}}', '"{table_name}"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{{{table_name_key}}}', '"{table_name}"'), '{{{operation_type}}}', '"{operation}"')::text FROM keys
         """.format(
                 table_name=self.table_name,
                 column_keys=", ".join(self.reference_columns),
                 select=self.selection,
                 table_name_key=MSG_JSON_TABLE_NAME_KEY,  # Assuming that no PK columns have the same name
+                operation_type=MSG_JSON_OPERATION_TYPE,
+                operation=self.op
             )
 
 

--- a/sir/trigger_generation/sql_generator.py
+++ b/sir/trigger_generation/sql_generator.py
@@ -25,7 +25,7 @@ class TriggerGenerator(object):
     # (`update`, `delete`, or `index`)
     routing_key = None
 
-    def __init__(self, table_name, pk_columns, broker_id=1):
+    def __init__(self, table_name, pk_columns, fk_columns, broker_id=1):
         """
         :param str table_name: The table on which to generate the trigger.
         :param pk_columns: List of primary key column names for a table that
@@ -33,7 +33,7 @@ class TriggerGenerator(object):
         :param int broker_id: ID of the AMQP broker row in a database.
         """
         self.table_name = table_name
-        self.reference_columns = pk_columns
+        self.reference_columns = list(set(pk_columns + fk_columns))
         self.reference_columns.sort()
         self.broker_id = broker_id
 

--- a/sir/trigger_generation/test/test_paths.py
+++ b/sir/trigger_generation/test/test_paths.py
@@ -42,3 +42,9 @@ class PathsTestCase(unittest.TestCase):
             expected_sql="SELECT artist_credit_name.artist FROM musicbrainz.artist_credit_name WHERE artist_credit_name.artist_credit IN (:ids)",
             expected_pk="artist_credit",
         )
+        validate_selection(
+            core_name="recording",
+            path="artist_credit",
+            expected_sql="SELECT recording.id FROM musicbrainz.recording WHERE recording.artist_credit IN (:ids)",
+            expected_pk="artist_credit",
+        )

--- a/sir/trigger_generation/test/test_paths.py
+++ b/sir/trigger_generation/test/test_paths.py
@@ -21,7 +21,7 @@ class PathsTestCase(unittest.TestCase):
         validate_selection(
             core_name="annotation",
             path="releases.release",
-            expected_sql="SELECT release_annotation.annotation FROM musicbrainz.release_annotation WHERE release_annotation.release IN (:ids)",
+            expected_sql="SELECT release_annotation.annotation FROM musicbrainz.release_annotation WHERE release_annotation.release IN (SELECT release_annotation.release FROM musicbrainz.release_annotation WHERE release_annotation.release IN (:ids))",
             expected_pk="id",
         )
         validate_selection(
@@ -46,5 +46,5 @@ class PathsTestCase(unittest.TestCase):
             core_name="recording",
             path="artist_credit",
             expected_sql="SELECT recording.id FROM musicbrainz.recording WHERE recording.artist_credit IN (:ids)",
-            expected_pk="artist_credit",
+            expected_pk="id",
         )

--- a/sql/CreateFunctions.sql
+++ b/sql/CreateFunctions.sql
@@ -765,7 +765,7 @@ CREATE OR REPLACE FUNCTION search_area_alias_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(area, id, type) AS (SELECT NEW.area, NEW.id, NEW.type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"area_alias"')::text FROM keys
         ));
     RETURN NEW;
@@ -776,7 +776,7 @@ CREATE OR REPLACE FUNCTION search_area_alias_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(area, id, type) AS (SELECT NEW.area, NEW.id, NEW.type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"area_alias"')::text FROM keys
         ));
     RETURN NEW;
@@ -787,7 +787,7 @@ CREATE OR REPLACE FUNCTION search_area_alias_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(area, id, type) AS (SELECT OLD.area, OLD.id, OLD.type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"area_alias"')::text FROM keys
         ));
     RETURN OLD;
@@ -798,7 +798,7 @@ CREATE OR REPLACE FUNCTION search_iso_3166_1_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(code) AS (SELECT NEW.code)
+            WITH keys(area, code) AS (SELECT NEW.area, NEW.code)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_1"')::text FROM keys
         ));
     RETURN NEW;
@@ -809,7 +809,7 @@ CREATE OR REPLACE FUNCTION search_iso_3166_1_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(code) AS (SELECT NEW.code)
+            WITH keys(area, code) AS (SELECT NEW.area, NEW.code)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_1"')::text FROM keys
         ));
     RETURN NEW;
@@ -820,7 +820,7 @@ CREATE OR REPLACE FUNCTION search_iso_3166_1_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(code) AS (SELECT OLD.code)
+            WITH keys(area, code) AS (SELECT OLD.area, OLD.code)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_1"')::text FROM keys
         ));
     RETURN OLD;
@@ -831,7 +831,7 @@ CREATE OR REPLACE FUNCTION search_iso_3166_2_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(code) AS (SELECT NEW.code)
+            WITH keys(area, code) AS (SELECT NEW.area, NEW.code)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_2"')::text FROM keys
         ));
     RETURN NEW;
@@ -842,7 +842,7 @@ CREATE OR REPLACE FUNCTION search_iso_3166_2_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(code) AS (SELECT NEW.code)
+            WITH keys(area, code) AS (SELECT NEW.area, NEW.code)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_2"')::text FROM keys
         ));
     RETURN NEW;
@@ -853,7 +853,7 @@ CREATE OR REPLACE FUNCTION search_iso_3166_2_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(code) AS (SELECT OLD.code)
+            WITH keys(area, code) AS (SELECT OLD.area, OLD.code)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_2"')::text FROM keys
         ));
     RETURN OLD;
@@ -864,7 +864,7 @@ CREATE OR REPLACE FUNCTION search_iso_3166_3_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(code) AS (SELECT NEW.code)
+            WITH keys(area, code) AS (SELECT NEW.area, NEW.code)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_3"')::text FROM keys
         ));
     RETURN NEW;
@@ -875,7 +875,7 @@ CREATE OR REPLACE FUNCTION search_iso_3166_3_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(code) AS (SELECT NEW.code)
+            WITH keys(area, code) AS (SELECT NEW.area, NEW.code)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_3"')::text FROM keys
         ));
     RETURN NEW;
@@ -886,7 +886,7 @@ CREATE OR REPLACE FUNCTION search_iso_3166_3_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(code) AS (SELECT OLD.code)
+            WITH keys(area, code) AS (SELECT OLD.area, OLD.code)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_3"')::text FROM keys
         ));
     RETURN OLD;
@@ -963,7 +963,7 @@ CREATE OR REPLACE FUNCTION search_area_type_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"area_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -974,7 +974,7 @@ CREATE OR REPLACE FUNCTION search_area_type_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"area_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -985,7 +985,7 @@ CREATE OR REPLACE FUNCTION search_area_type_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"area_type"')::text FROM keys
         ));
     RETURN OLD;
@@ -996,7 +996,7 @@ CREATE OR REPLACE FUNCTION search_artist_alias_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(artist, id, type) AS (SELECT NEW.artist, NEW.id, NEW.type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_alias"')::text FROM keys
         ));
     RETURN NEW;
@@ -1007,7 +1007,7 @@ CREATE OR REPLACE FUNCTION search_artist_alias_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(artist, id, type) AS (SELECT NEW.artist, NEW.id, NEW.type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_alias"')::text FROM keys
         ));
     RETURN NEW;
@@ -1018,7 +1018,7 @@ CREATE OR REPLACE FUNCTION search_artist_alias_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(artist, id, type) AS (SELECT OLD.artist, OLD.id, OLD.type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_alias"')::text FROM keys
         ));
     RETURN OLD;
@@ -1029,7 +1029,7 @@ CREATE OR REPLACE FUNCTION search_gender_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"gender"')::text FROM keys
         ));
     RETURN NEW;
@@ -1040,7 +1040,7 @@ CREATE OR REPLACE FUNCTION search_gender_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"gender"')::text FROM keys
         ));
     RETURN NEW;
@@ -1051,7 +1051,7 @@ CREATE OR REPLACE FUNCTION search_gender_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"gender"')::text FROM keys
         ));
     RETURN OLD;
@@ -1161,7 +1161,7 @@ CREATE OR REPLACE FUNCTION search_artist_credit_name_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(artist_credit, position) AS (SELECT NEW.artist_credit, NEW.position)
+            WITH keys(artist, artist_credit, position) AS (SELECT NEW.artist, NEW.artist_credit, NEW.position)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_credit_name"')::text FROM keys
         ));
     RETURN NEW;
@@ -1172,7 +1172,7 @@ CREATE OR REPLACE FUNCTION search_artist_credit_name_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(artist_credit, position) AS (SELECT NEW.artist_credit, NEW.position)
+            WITH keys(artist, artist_credit, position) AS (SELECT NEW.artist, NEW.artist_credit, NEW.position)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_credit_name"')::text FROM keys
         ));
     RETURN NEW;
@@ -1183,7 +1183,7 @@ CREATE OR REPLACE FUNCTION search_artist_credit_name_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(artist_credit, position) AS (SELECT OLD.artist_credit, OLD.position)
+            WITH keys(artist, artist_credit, position) AS (SELECT OLD.artist, OLD.artist_credit, OLD.position)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_credit_name"')::text FROM keys
         ));
     RETURN OLD;
@@ -1227,7 +1227,7 @@ CREATE OR REPLACE FUNCTION search_artist_type_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -1238,7 +1238,7 @@ CREATE OR REPLACE FUNCTION search_artist_type_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -1249,7 +1249,7 @@ CREATE OR REPLACE FUNCTION search_artist_type_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_type"')::text FROM keys
         ));
     RETURN OLD;
@@ -1293,7 +1293,7 @@ CREATE OR REPLACE FUNCTION search_cdtoc_raw_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, release) AS (SELECT NEW.id, NEW.release)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"cdtoc_raw"')::text FROM keys
         ));
     RETURN NEW;
@@ -1304,7 +1304,7 @@ CREATE OR REPLACE FUNCTION search_cdtoc_raw_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, release) AS (SELECT NEW.id, NEW.release)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"cdtoc_raw"')::text FROM keys
         ));
     RETURN NEW;
@@ -1315,7 +1315,7 @@ CREATE OR REPLACE FUNCTION search_cdtoc_raw_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, release) AS (SELECT OLD.id, OLD.release)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"cdtoc_raw"')::text FROM keys
         ));
     RETURN OLD;
@@ -1359,7 +1359,7 @@ CREATE OR REPLACE FUNCTION search_event_alias_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(event, id, type) AS (SELECT NEW.event, NEW.id, NEW.type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"event_alias"')::text FROM keys
         ));
     RETURN NEW;
@@ -1370,7 +1370,7 @@ CREATE OR REPLACE FUNCTION search_event_alias_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(event, id, type) AS (SELECT NEW.event, NEW.id, NEW.type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"event_alias"')::text FROM keys
         ));
     RETURN NEW;
@@ -1381,7 +1381,7 @@ CREATE OR REPLACE FUNCTION search_event_alias_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(event, id, type) AS (SELECT OLD.event, OLD.id, OLD.type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"event_alias"')::text FROM keys
         ));
     RETURN OLD;
@@ -1392,7 +1392,7 @@ CREATE OR REPLACE FUNCTION search_l_area_event_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_area_event"')::text FROM keys
         ));
     RETURN NEW;
@@ -1403,7 +1403,7 @@ CREATE OR REPLACE FUNCTION search_l_area_event_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_area_event"')::text FROM keys
         ));
     RETURN NEW;
@@ -1414,7 +1414,7 @@ CREATE OR REPLACE FUNCTION search_l_area_event_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(entity0, entity1, id, link) AS (SELECT OLD.entity0, OLD.entity1, OLD.id, OLD.link)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_area_event"')::text FROM keys
         ));
     RETURN OLD;
@@ -1425,7 +1425,7 @@ CREATE OR REPLACE FUNCTION search_l_artist_event_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_event"')::text FROM keys
         ));
     RETURN NEW;
@@ -1436,7 +1436,7 @@ CREATE OR REPLACE FUNCTION search_l_artist_event_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_event"')::text FROM keys
         ));
     RETURN NEW;
@@ -1447,7 +1447,7 @@ CREATE OR REPLACE FUNCTION search_l_artist_event_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(entity0, entity1, id, link) AS (SELECT OLD.entity0, OLD.entity1, OLD.id, OLD.link)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_event"')::text FROM keys
         ));
     RETURN OLD;
@@ -1458,7 +1458,7 @@ CREATE OR REPLACE FUNCTION search_l_event_place_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_event_place"')::text FROM keys
         ));
     RETURN NEW;
@@ -1469,7 +1469,7 @@ CREATE OR REPLACE FUNCTION search_l_event_place_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_event_place"')::text FROM keys
         ));
     RETURN NEW;
@@ -1480,7 +1480,7 @@ CREATE OR REPLACE FUNCTION search_l_event_place_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(entity0, entity1, id, link) AS (SELECT OLD.entity0, OLD.entity1, OLD.id, OLD.link)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_event_place"')::text FROM keys
         ));
     RETURN OLD;
@@ -1524,7 +1524,7 @@ CREATE OR REPLACE FUNCTION search_event_type_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"event_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -1535,7 +1535,7 @@ CREATE OR REPLACE FUNCTION search_event_type_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"event_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -1546,7 +1546,7 @@ CREATE OR REPLACE FUNCTION search_event_type_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"event_type"')::text FROM keys
         ));
     RETURN OLD;
@@ -1557,7 +1557,7 @@ CREATE OR REPLACE FUNCTION search_instrument_alias_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, instrument, type) AS (SELECT NEW.id, NEW.instrument, NEW.type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"instrument_alias"')::text FROM keys
         ));
     RETURN NEW;
@@ -1568,7 +1568,7 @@ CREATE OR REPLACE FUNCTION search_instrument_alias_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, instrument, type) AS (SELECT NEW.id, NEW.instrument, NEW.type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"instrument_alias"')::text FROM keys
         ));
     RETURN NEW;
@@ -1579,7 +1579,7 @@ CREATE OR REPLACE FUNCTION search_instrument_alias_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, instrument, type) AS (SELECT OLD.id, OLD.instrument, OLD.type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"instrument_alias"')::text FROM keys
         ));
     RETURN OLD;
@@ -1623,7 +1623,7 @@ CREATE OR REPLACE FUNCTION search_instrument_type_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"instrument_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -1634,7 +1634,7 @@ CREATE OR REPLACE FUNCTION search_instrument_type_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"instrument_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -1645,7 +1645,7 @@ CREATE OR REPLACE FUNCTION search_instrument_type_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"instrument_type"')::text FROM keys
         ));
     RETURN OLD;
@@ -1656,7 +1656,7 @@ CREATE OR REPLACE FUNCTION search_label_alias_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, label, type) AS (SELECT NEW.id, NEW.label, NEW.type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label_alias"')::text FROM keys
         ));
     RETURN NEW;
@@ -1667,7 +1667,7 @@ CREATE OR REPLACE FUNCTION search_label_alias_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, label, type) AS (SELECT NEW.id, NEW.label, NEW.type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label_alias"')::text FROM keys
         ));
     RETURN NEW;
@@ -1678,7 +1678,7 @@ CREATE OR REPLACE FUNCTION search_label_alias_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, label, type) AS (SELECT OLD.id, OLD.label, OLD.type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label_alias"')::text FROM keys
         ));
     RETURN OLD;
@@ -1755,7 +1755,7 @@ CREATE OR REPLACE FUNCTION search_label_type_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -1766,7 +1766,7 @@ CREATE OR REPLACE FUNCTION search_label_type_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -1777,7 +1777,7 @@ CREATE OR REPLACE FUNCTION search_label_type_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label_type"')::text FROM keys
         ));
     RETURN OLD;
@@ -1788,7 +1788,7 @@ CREATE OR REPLACE FUNCTION search_place_alias_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, place, type) AS (SELECT NEW.id, NEW.place, NEW.type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"place_alias"')::text FROM keys
         ));
     RETURN NEW;
@@ -1799,7 +1799,7 @@ CREATE OR REPLACE FUNCTION search_place_alias_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, place, type) AS (SELECT NEW.id, NEW.place, NEW.type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"place_alias"')::text FROM keys
         ));
     RETURN NEW;
@@ -1810,7 +1810,7 @@ CREATE OR REPLACE FUNCTION search_place_alias_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, place, type) AS (SELECT OLD.id, OLD.place, OLD.type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"place_alias"')::text FROM keys
         ));
     RETURN OLD;
@@ -1821,7 +1821,7 @@ CREATE OR REPLACE FUNCTION search_place_type_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"place_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -1832,7 +1832,7 @@ CREATE OR REPLACE FUNCTION search_place_type_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"place_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -1843,7 +1843,7 @@ CREATE OR REPLACE FUNCTION search_place_type_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"place_type"')::text FROM keys
         ));
     RETURN OLD;
@@ -1854,7 +1854,7 @@ CREATE OR REPLACE FUNCTION search_track_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(artist_credit, id, medium, recording) AS (SELECT NEW.artist_credit, NEW.id, NEW.medium, NEW.recording)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"track"')::text FROM keys
         ));
     RETURN NEW;
@@ -1865,7 +1865,7 @@ CREATE OR REPLACE FUNCTION search_track_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(artist_credit, id, medium, recording) AS (SELECT NEW.artist_credit, NEW.id, NEW.medium, NEW.recording)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"track"')::text FROM keys
         ));
     RETURN NEW;
@@ -1876,7 +1876,7 @@ CREATE OR REPLACE FUNCTION search_track_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(artist_credit, id, medium, recording) AS (SELECT OLD.artist_credit, OLD.id, OLD.medium, OLD.recording)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"track"')::text FROM keys
         ));
     RETURN OLD;
@@ -1887,7 +1887,7 @@ CREATE OR REPLACE FUNCTION search_medium_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(format, id, release) AS (SELECT NEW.format, NEW.id, NEW.release)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"medium"')::text FROM keys
         ));
     RETURN NEW;
@@ -1898,7 +1898,7 @@ CREATE OR REPLACE FUNCTION search_medium_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(format, id, release) AS (SELECT NEW.format, NEW.id, NEW.release)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"medium"')::text FROM keys
         ));
     RETURN NEW;
@@ -1909,7 +1909,7 @@ CREATE OR REPLACE FUNCTION search_medium_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(format, id, release) AS (SELECT OLD.format, OLD.id, OLD.release)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"medium"')::text FROM keys
         ));
     RETURN OLD;
@@ -1986,7 +1986,7 @@ CREATE OR REPLACE FUNCTION search_medium_format_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"medium_format"')::text FROM keys
         ));
     RETURN NEW;
@@ -1997,7 +1997,7 @@ CREATE OR REPLACE FUNCTION search_medium_format_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"medium_format"')::text FROM keys
         ));
     RETURN NEW;
@@ -2008,7 +2008,7 @@ CREATE OR REPLACE FUNCTION search_medium_format_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"medium_format"')::text FROM keys
         ));
     RETURN OLD;
@@ -2019,7 +2019,7 @@ CREATE OR REPLACE FUNCTION search_isrc_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, recording) AS (SELECT NEW.id, NEW.recording)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"isrc"')::text FROM keys
         ));
     RETURN NEW;
@@ -2030,7 +2030,7 @@ CREATE OR REPLACE FUNCTION search_isrc_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, recording) AS (SELECT NEW.id, NEW.recording)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"isrc"')::text FROM keys
         ));
     RETURN NEW;
@@ -2041,7 +2041,7 @@ CREATE OR REPLACE FUNCTION search_isrc_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, recording) AS (SELECT OLD.id, OLD.recording)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"isrc"')::text FROM keys
         ));
     RETURN OLD;
@@ -2052,7 +2052,7 @@ CREATE OR REPLACE FUNCTION search_release_group_primary_type_insert() RETURNS tr
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group_primary_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -2063,7 +2063,7 @@ CREATE OR REPLACE FUNCTION search_release_group_primary_type_update() RETURNS tr
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group_primary_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -2074,7 +2074,7 @@ CREATE OR REPLACE FUNCTION search_release_group_primary_type_delete() RETURNS tr
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group_primary_type"')::text FROM keys
         ));
     RETURN OLD;
@@ -2118,7 +2118,7 @@ CREATE OR REPLACE FUNCTION search_release_group_secondary_type_insert() RETURNS 
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group_secondary_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -2129,7 +2129,7 @@ CREATE OR REPLACE FUNCTION search_release_group_secondary_type_update() RETURNS 
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group_secondary_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -2140,7 +2140,7 @@ CREATE OR REPLACE FUNCTION search_release_group_secondary_type_delete() RETURNS 
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group_secondary_type"')::text FROM keys
         ));
     RETURN OLD;
@@ -2151,7 +2151,7 @@ CREATE OR REPLACE FUNCTION search_release_status_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_status"')::text FROM keys
         ));
     RETURN NEW;
@@ -2162,7 +2162,7 @@ CREATE OR REPLACE FUNCTION search_release_status_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_status"')::text FROM keys
         ));
     RETURN NEW;
@@ -2173,7 +2173,7 @@ CREATE OR REPLACE FUNCTION search_release_status_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_status"')::text FROM keys
         ));
     RETURN OLD;
@@ -2250,7 +2250,7 @@ CREATE OR REPLACE FUNCTION search_release_label_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, label, release) AS (SELECT NEW.id, NEW.label, NEW.release)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_label"')::text FROM keys
         ));
     RETURN NEW;
@@ -2261,7 +2261,7 @@ CREATE OR REPLACE FUNCTION search_release_label_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, label, release) AS (SELECT NEW.id, NEW.label, NEW.release)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_label"')::text FROM keys
         ));
     RETURN NEW;
@@ -2272,7 +2272,7 @@ CREATE OR REPLACE FUNCTION search_release_label_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, label, release) AS (SELECT OLD.id, OLD.label, OLD.release)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_label"')::text FROM keys
         ));
     RETURN OLD;
@@ -2283,7 +2283,7 @@ CREATE OR REPLACE FUNCTION search_medium_cdtoc_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(cdtoc, id, medium) AS (SELECT NEW.cdtoc, NEW.id, NEW.medium)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"medium_cdtoc"')::text FROM keys
         ));
     RETURN NEW;
@@ -2294,7 +2294,7 @@ CREATE OR REPLACE FUNCTION search_medium_cdtoc_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(cdtoc, id, medium) AS (SELECT NEW.cdtoc, NEW.id, NEW.medium)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"medium_cdtoc"')::text FROM keys
         ));
     RETURN NEW;
@@ -2305,7 +2305,7 @@ CREATE OR REPLACE FUNCTION search_medium_cdtoc_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(cdtoc, id, medium) AS (SELECT OLD.cdtoc, OLD.id, OLD.medium)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"medium_cdtoc"')::text FROM keys
         ));
     RETURN OLD;
@@ -2448,7 +2448,7 @@ CREATE OR REPLACE FUNCTION search_series_alias_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, series, type) AS (SELECT NEW.id, NEW.series, NEW.type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"series_alias"')::text FROM keys
         ));
     RETURN NEW;
@@ -2459,7 +2459,7 @@ CREATE OR REPLACE FUNCTION search_series_alias_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, series, type) AS (SELECT NEW.id, NEW.series, NEW.type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"series_alias"')::text FROM keys
         ));
     RETURN NEW;
@@ -2470,7 +2470,7 @@ CREATE OR REPLACE FUNCTION search_series_alias_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, series, type) AS (SELECT OLD.id, OLD.series, OLD.type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"series_alias"')::text FROM keys
         ));
     RETURN OLD;
@@ -2481,7 +2481,7 @@ CREATE OR REPLACE FUNCTION search_link_attribute_type_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent, root) AS (SELECT NEW.id, NEW.parent, NEW.root)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"link_attribute_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -2492,7 +2492,7 @@ CREATE OR REPLACE FUNCTION search_link_attribute_type_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent, root) AS (SELECT NEW.id, NEW.parent, NEW.root)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"link_attribute_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -2503,7 +2503,7 @@ CREATE OR REPLACE FUNCTION search_link_attribute_type_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, parent, root) AS (SELECT OLD.id, OLD.parent, OLD.root)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"link_attribute_type"')::text FROM keys
         ));
     RETURN OLD;
@@ -2547,7 +2547,7 @@ CREATE OR REPLACE FUNCTION search_series_type_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"series_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -2558,7 +2558,7 @@ CREATE OR REPLACE FUNCTION search_series_type_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"series_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -2569,7 +2569,7 @@ CREATE OR REPLACE FUNCTION search_series_type_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"series_type"')::text FROM keys
         ));
     RETURN OLD;
@@ -2613,7 +2613,7 @@ CREATE OR REPLACE FUNCTION search_l_artist_url_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_url"')::text FROM keys
         ));
     RETURN NEW;
@@ -2624,7 +2624,7 @@ CREATE OR REPLACE FUNCTION search_l_artist_url_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_url"')::text FROM keys
         ));
     RETURN NEW;
@@ -2635,7 +2635,7 @@ CREATE OR REPLACE FUNCTION search_l_artist_url_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(entity0, entity1, id, link) AS (SELECT OLD.entity0, OLD.entity1, OLD.id, OLD.link)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_url"')::text FROM keys
         ));
     RETURN OLD;
@@ -2646,7 +2646,7 @@ CREATE OR REPLACE FUNCTION search_link_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, link_type) AS (SELECT NEW.id, NEW.link_type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"link"')::text FROM keys
         ));
     RETURN NEW;
@@ -2657,7 +2657,7 @@ CREATE OR REPLACE FUNCTION search_link_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, link_type) AS (SELECT NEW.id, NEW.link_type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"link"')::text FROM keys
         ));
     RETURN NEW;
@@ -2668,7 +2668,7 @@ CREATE OR REPLACE FUNCTION search_link_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, link_type) AS (SELECT OLD.id, OLD.link_type)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"link"')::text FROM keys
         ));
     RETURN OLD;
@@ -2679,7 +2679,7 @@ CREATE OR REPLACE FUNCTION search_link_type_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"link_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -2690,7 +2690,7 @@ CREATE OR REPLACE FUNCTION search_link_type_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"link_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -2701,7 +2701,7 @@ CREATE OR REPLACE FUNCTION search_link_type_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"link_type"')::text FROM keys
         ));
     RETURN OLD;
@@ -2712,7 +2712,7 @@ CREATE OR REPLACE FUNCTION search_work_alias_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, type, work) AS (SELECT NEW.id, NEW.type, NEW.work)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work_alias"')::text FROM keys
         ));
     RETURN NEW;
@@ -2723,7 +2723,7 @@ CREATE OR REPLACE FUNCTION search_work_alias_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, type, work) AS (SELECT NEW.id, NEW.type, NEW.work)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work_alias"')::text FROM keys
         ));
     RETURN NEW;
@@ -2734,7 +2734,7 @@ CREATE OR REPLACE FUNCTION search_work_alias_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, type, work) AS (SELECT OLD.id, OLD.type, OLD.work)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work_alias"')::text FROM keys
         ));
     RETURN OLD;
@@ -2745,7 +2745,7 @@ CREATE OR REPLACE FUNCTION search_l_artist_work_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_work"')::text FROM keys
         ));
     RETURN NEW;
@@ -2756,7 +2756,7 @@ CREATE OR REPLACE FUNCTION search_l_artist_work_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_work"')::text FROM keys
         ));
     RETURN NEW;
@@ -2767,7 +2767,7 @@ CREATE OR REPLACE FUNCTION search_l_artist_work_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(entity0, entity1, id, link) AS (SELECT OLD.entity0, OLD.entity1, OLD.id, OLD.link)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_work"')::text FROM keys
         ));
     RETURN OLD;
@@ -2778,7 +2778,7 @@ CREATE OR REPLACE FUNCTION search_iswc_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, work) AS (SELECT NEW.id, NEW.work)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iswc"')::text FROM keys
         ));
     RETURN NEW;
@@ -2789,7 +2789,7 @@ CREATE OR REPLACE FUNCTION search_iswc_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, work) AS (SELECT NEW.id, NEW.work)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iswc"')::text FROM keys
         ));
     RETURN NEW;
@@ -2800,7 +2800,7 @@ CREATE OR REPLACE FUNCTION search_iswc_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, work) AS (SELECT OLD.id, OLD.work)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iswc"')::text FROM keys
         ));
     RETURN OLD;
@@ -2844,7 +2844,7 @@ CREATE OR REPLACE FUNCTION search_l_recording_work_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_recording_work"')::text FROM keys
         ));
     RETURN NEW;
@@ -2855,7 +2855,7 @@ CREATE OR REPLACE FUNCTION search_l_recording_work_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_recording_work"')::text FROM keys
         ));
     RETURN NEW;
@@ -2866,7 +2866,7 @@ CREATE OR REPLACE FUNCTION search_l_recording_work_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(entity0, entity1, id, link) AS (SELECT OLD.entity0, OLD.entity1, OLD.id, OLD.link)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_recording_work"')::text FROM keys
         ));
     RETURN OLD;
@@ -2910,7 +2910,7 @@ CREATE OR REPLACE FUNCTION search_work_type_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -2921,7 +2921,7 @@ CREATE OR REPLACE FUNCTION search_work_type_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work_type"')::text FROM keys
         ));
     RETURN NEW;
@@ -2932,7 +2932,7 @@ CREATE OR REPLACE FUNCTION search_work_type_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
             SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work_type"')::text FROM keys
         ));
     RETURN OLD;

--- a/sql/CreateFunctions.sql
+++ b/sql/CreateFunctions.sql
@@ -1050,7 +1050,7 @@ CREATE OR REPLACE FUNCTION search_area_type_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"area_type"'),
                              '{_operation}', '"insert"')::text FROM keys
         ));
@@ -1062,7 +1062,7 @@ CREATE OR REPLACE FUNCTION search_area_type_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"area_type"'),
                              '{_operation}', '"update"')::text FROM keys
         ));
@@ -1074,7 +1074,7 @@ CREATE OR REPLACE FUNCTION search_area_type_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
+            WITH keys(id) AS (SELECT OLD.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"area_type"'),
                              '{_operation}', '"delete"')::text FROM keys
         ));
@@ -1122,7 +1122,7 @@ CREATE OR REPLACE FUNCTION search_gender_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"gender"'),
                              '{_operation}', '"insert"')::text FROM keys
         ));
@@ -1134,7 +1134,7 @@ CREATE OR REPLACE FUNCTION search_gender_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"gender"'),
                              '{_operation}', '"update"')::text FROM keys
         ));
@@ -1146,7 +1146,7 @@ CREATE OR REPLACE FUNCTION search_gender_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
+            WITH keys(id) AS (SELECT OLD.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"gender"'),
                              '{_operation}', '"delete"')::text FROM keys
         ));
@@ -1338,7 +1338,7 @@ CREATE OR REPLACE FUNCTION search_artist_type_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_type"'),
                              '{_operation}', '"insert"')::text FROM keys
         ));
@@ -1350,7 +1350,7 @@ CREATE OR REPLACE FUNCTION search_artist_type_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_type"'),
                              '{_operation}', '"update"')::text FROM keys
         ));
@@ -1362,7 +1362,7 @@ CREATE OR REPLACE FUNCTION search_artist_type_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
+            WITH keys(id) AS (SELECT OLD.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_type"'),
                              '{_operation}', '"delete"')::text FROM keys
         ));
@@ -1662,7 +1662,7 @@ CREATE OR REPLACE FUNCTION search_event_type_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"event_type"'),
                              '{_operation}', '"insert"')::text FROM keys
         ));
@@ -1674,7 +1674,7 @@ CREATE OR REPLACE FUNCTION search_event_type_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"event_type"'),
                              '{_operation}', '"update"')::text FROM keys
         ));
@@ -1686,7 +1686,7 @@ CREATE OR REPLACE FUNCTION search_event_type_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
+            WITH keys(id) AS (SELECT OLD.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"event_type"'),
                              '{_operation}', '"delete"')::text FROM keys
         ));
@@ -1770,7 +1770,7 @@ CREATE OR REPLACE FUNCTION search_instrument_type_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"instrument_type"'),
                              '{_operation}', '"insert"')::text FROM keys
         ));
@@ -1782,7 +1782,7 @@ CREATE OR REPLACE FUNCTION search_instrument_type_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"instrument_type"'),
                              '{_operation}', '"update"')::text FROM keys
         ));
@@ -1794,7 +1794,7 @@ CREATE OR REPLACE FUNCTION search_instrument_type_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
+            WITH keys(id) AS (SELECT OLD.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"instrument_type"'),
                              '{_operation}', '"delete"')::text FROM keys
         ));
@@ -1914,7 +1914,7 @@ CREATE OR REPLACE FUNCTION search_label_type_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"label_type"'),
                              '{_operation}', '"insert"')::text FROM keys
         ));
@@ -1926,7 +1926,7 @@ CREATE OR REPLACE FUNCTION search_label_type_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"label_type"'),
                              '{_operation}', '"update"')::text FROM keys
         ));
@@ -1938,7 +1938,7 @@ CREATE OR REPLACE FUNCTION search_label_type_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
+            WITH keys(id) AS (SELECT OLD.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"label_type"'),
                              '{_operation}', '"delete"')::text FROM keys
         ));
@@ -1986,7 +1986,7 @@ CREATE OR REPLACE FUNCTION search_place_type_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"place_type"'),
                              '{_operation}', '"insert"')::text FROM keys
         ));
@@ -1998,7 +1998,7 @@ CREATE OR REPLACE FUNCTION search_place_type_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"place_type"'),
                              '{_operation}', '"update"')::text FROM keys
         ));
@@ -2010,7 +2010,7 @@ CREATE OR REPLACE FUNCTION search_place_type_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
+            WITH keys(id) AS (SELECT OLD.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"place_type"'),
                              '{_operation}', '"delete"')::text FROM keys
         ));
@@ -2166,7 +2166,7 @@ CREATE OR REPLACE FUNCTION search_medium_format_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"medium_format"'),
                              '{_operation}', '"insert"')::text FROM keys
         ));
@@ -2178,7 +2178,7 @@ CREATE OR REPLACE FUNCTION search_medium_format_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"medium_format"'),
                              '{_operation}', '"update"')::text FROM keys
         ));
@@ -2190,7 +2190,7 @@ CREATE OR REPLACE FUNCTION search_medium_format_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
+            WITH keys(id) AS (SELECT OLD.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"medium_format"'),
                              '{_operation}', '"delete"')::text FROM keys
         ));
@@ -2238,7 +2238,7 @@ CREATE OR REPLACE FUNCTION search_release_group_primary_type_insert() RETURNS tr
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_primary_type"'),
                              '{_operation}', '"insert"')::text FROM keys
         ));
@@ -2250,7 +2250,7 @@ CREATE OR REPLACE FUNCTION search_release_group_primary_type_update() RETURNS tr
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_primary_type"'),
                              '{_operation}', '"update"')::text FROM keys
         ));
@@ -2262,7 +2262,7 @@ CREATE OR REPLACE FUNCTION search_release_group_primary_type_delete() RETURNS tr
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
+            WITH keys(id) AS (SELECT OLD.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_primary_type"'),
                              '{_operation}', '"delete"')::text FROM keys
         ));
@@ -2310,7 +2310,7 @@ CREATE OR REPLACE FUNCTION search_release_group_secondary_type_insert() RETURNS 
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_secondary_type"'),
                              '{_operation}', '"insert"')::text FROM keys
         ));
@@ -2322,7 +2322,7 @@ CREATE OR REPLACE FUNCTION search_release_group_secondary_type_update() RETURNS 
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_secondary_type"'),
                              '{_operation}', '"update"')::text FROM keys
         ));
@@ -2334,7 +2334,7 @@ CREATE OR REPLACE FUNCTION search_release_group_secondary_type_delete() RETURNS 
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
+            WITH keys(id) AS (SELECT OLD.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_secondary_type"'),
                              '{_operation}', '"delete"')::text FROM keys
         ));
@@ -2346,7 +2346,7 @@ CREATE OR REPLACE FUNCTION search_release_status_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_status"'),
                              '{_operation}', '"insert"')::text FROM keys
         ));
@@ -2358,7 +2358,7 @@ CREATE OR REPLACE FUNCTION search_release_status_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_status"'),
                              '{_operation}', '"update"')::text FROM keys
         ));
@@ -2370,7 +2370,7 @@ CREATE OR REPLACE FUNCTION search_release_status_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
+            WITH keys(id) AS (SELECT OLD.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_status"'),
                              '{_operation}', '"delete"')::text FROM keys
         ));
@@ -2418,7 +2418,7 @@ CREATE OR REPLACE FUNCTION search_release_meta_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, release) AS (SELECT NEW.id, NEW.release)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_meta"'),
                              '{_operation}', '"insert"')::text FROM keys
         ));
@@ -2430,7 +2430,7 @@ CREATE OR REPLACE FUNCTION search_release_meta_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
+            WITH keys(id, release) AS (SELECT NEW.id, NEW.release)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_meta"'),
                              '{_operation}', '"update"')::text FROM keys
         ));
@@ -2442,7 +2442,7 @@ CREATE OR REPLACE FUNCTION search_release_meta_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
+            WITH keys(id, release) AS (SELECT OLD.id, OLD.release)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_meta"'),
                              '{_operation}', '"delete"')::text FROM keys
         ));
@@ -2706,7 +2706,7 @@ CREATE OR REPLACE FUNCTION search_link_attribute_type_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id, parent, root) AS (SELECT NEW.id, NEW.parent, NEW.root)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"link_attribute_type"'),
                              '{_operation}', '"insert"')::text FROM keys
         ));
@@ -2718,7 +2718,7 @@ CREATE OR REPLACE FUNCTION search_link_attribute_type_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent, root) AS (SELECT NEW.id, NEW.parent, NEW.root)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"link_attribute_type"'),
                              '{_operation}', '"update"')::text FROM keys
         ));
@@ -2730,7 +2730,7 @@ CREATE OR REPLACE FUNCTION search_link_attribute_type_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent, root) AS (SELECT OLD.id, OLD.parent, OLD.root)
+            WITH keys(id) AS (SELECT OLD.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"link_attribute_type"'),
                              '{_operation}', '"delete"')::text FROM keys
         ));
@@ -2778,7 +2778,7 @@ CREATE OR REPLACE FUNCTION search_series_type_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"series_type"'),
                              '{_operation}', '"insert"')::text FROM keys
         ));
@@ -2790,7 +2790,7 @@ CREATE OR REPLACE FUNCTION search_series_type_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"series_type"'),
                              '{_operation}', '"update"')::text FROM keys
         ));
@@ -2802,7 +2802,7 @@ CREATE OR REPLACE FUNCTION search_series_type_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
+            WITH keys(id) AS (SELECT OLD.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"series_type"'),
                              '{_operation}', '"delete"')::text FROM keys
         ));
@@ -2922,7 +2922,7 @@ CREATE OR REPLACE FUNCTION search_link_type_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"link_type"'),
                              '{_operation}', '"insert"')::text FROM keys
         ));
@@ -2934,7 +2934,7 @@ CREATE OR REPLACE FUNCTION search_link_type_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"link_type"'),
                              '{_operation}', '"update"')::text FROM keys
         ));
@@ -2946,7 +2946,7 @@ CREATE OR REPLACE FUNCTION search_link_type_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
+            WITH keys(id) AS (SELECT OLD.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"link_type"'),
                              '{_operation}', '"delete"')::text FROM keys
         ));
@@ -3174,7 +3174,7 @@ CREATE OR REPLACE FUNCTION search_work_type_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"work_type"'),
                              '{_operation}', '"insert"')::text FROM keys
         ));
@@ -3186,7 +3186,7 @@ CREATE OR REPLACE FUNCTION search_work_type_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
+            WITH keys(id) AS (SELECT NEW.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"work_type"'),
                              '{_operation}', '"update"')::text FROM keys
         ));
@@ -3198,7 +3198,7 @@ CREATE OR REPLACE FUNCTION search_work_type_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
+            WITH keys(id) AS (SELECT OLD.id)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"work_type"'),
                              '{_operation}', '"delete"')::text FROM keys
         ));

--- a/sql/CreateFunctions.sql
+++ b/sql/CreateFunctions.sql
@@ -7,7 +7,8 @@ CREATE OR REPLACE FUNCTION search_annotation_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"annotation"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -18,7 +19,8 @@ CREATE OR REPLACE FUNCTION search_annotation_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"annotation"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -29,7 +31,8 @@ CREATE OR REPLACE FUNCTION search_annotation_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'delete', (
             WITH keys(id) AS (SELECT OLD.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"annotation"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -40,7 +43,8 @@ CREATE OR REPLACE FUNCTION search_area_annotation_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(annotation, area) AS (SELECT NEW.annotation, NEW.area)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"area_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"area_annotation"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -51,7 +55,8 @@ CREATE OR REPLACE FUNCTION search_area_annotation_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(annotation, area) AS (SELECT NEW.annotation, NEW.area)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"area_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"area_annotation"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -62,7 +67,8 @@ CREATE OR REPLACE FUNCTION search_area_annotation_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(annotation, area) AS (SELECT OLD.annotation, OLD.area)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"area_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"area_annotation"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -73,7 +79,8 @@ CREATE OR REPLACE FUNCTION search_area_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"area"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"area"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -84,7 +91,8 @@ CREATE OR REPLACE FUNCTION search_area_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"area"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"area"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -95,7 +103,8 @@ CREATE OR REPLACE FUNCTION search_area_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'delete', (
             WITH keys(gid) AS (SELECT OLD.gid)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"area"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"area"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -106,7 +115,8 @@ CREATE OR REPLACE FUNCTION search_artist_annotation_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(annotation, artist) AS (SELECT NEW.annotation, NEW.artist)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_annotation"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -117,7 +127,8 @@ CREATE OR REPLACE FUNCTION search_artist_annotation_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(annotation, artist) AS (SELECT NEW.annotation, NEW.artist)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_annotation"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -128,7 +139,8 @@ CREATE OR REPLACE FUNCTION search_artist_annotation_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(annotation, artist) AS (SELECT OLD.annotation, OLD.artist)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_annotation"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -139,7 +151,8 @@ CREATE OR REPLACE FUNCTION search_artist_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -150,7 +163,8 @@ CREATE OR REPLACE FUNCTION search_artist_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -161,7 +175,8 @@ CREATE OR REPLACE FUNCTION search_artist_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'delete', (
             WITH keys(gid) AS (SELECT OLD.gid)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -172,7 +187,8 @@ CREATE OR REPLACE FUNCTION search_event_annotation_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(annotation, event) AS (SELECT NEW.annotation, NEW.event)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"event_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"event_annotation"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -183,7 +199,8 @@ CREATE OR REPLACE FUNCTION search_event_annotation_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(annotation, event) AS (SELECT NEW.annotation, NEW.event)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"event_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"event_annotation"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -194,7 +211,8 @@ CREATE OR REPLACE FUNCTION search_event_annotation_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(annotation, event) AS (SELECT OLD.annotation, OLD.event)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"event_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"event_annotation"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -205,7 +223,8 @@ CREATE OR REPLACE FUNCTION search_event_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"event"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"event"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -216,7 +235,8 @@ CREATE OR REPLACE FUNCTION search_event_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"event"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"event"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -227,7 +247,8 @@ CREATE OR REPLACE FUNCTION search_event_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'delete', (
             WITH keys(gid) AS (SELECT OLD.gid)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"event"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"event"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -238,7 +259,8 @@ CREATE OR REPLACE FUNCTION search_instrument_annotation_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(annotation, instrument) AS (SELECT NEW.annotation, NEW.instrument)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"instrument_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"instrument_annotation"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -249,7 +271,8 @@ CREATE OR REPLACE FUNCTION search_instrument_annotation_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(annotation, instrument) AS (SELECT NEW.annotation, NEW.instrument)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"instrument_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"instrument_annotation"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -260,7 +283,8 @@ CREATE OR REPLACE FUNCTION search_instrument_annotation_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(annotation, instrument) AS (SELECT OLD.annotation, OLD.instrument)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"instrument_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"instrument_annotation"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -271,7 +295,8 @@ CREATE OR REPLACE FUNCTION search_instrument_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"instrument"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"instrument"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -282,7 +307,8 @@ CREATE OR REPLACE FUNCTION search_instrument_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"instrument"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"instrument"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -293,7 +319,8 @@ CREATE OR REPLACE FUNCTION search_instrument_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'delete', (
             WITH keys(gid) AS (SELECT OLD.gid)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"instrument"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"instrument"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -304,7 +331,8 @@ CREATE OR REPLACE FUNCTION search_label_annotation_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(annotation, label) AS (SELECT NEW.annotation, NEW.label)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"label_annotation"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -315,7 +343,8 @@ CREATE OR REPLACE FUNCTION search_label_annotation_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(annotation, label) AS (SELECT NEW.annotation, NEW.label)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"label_annotation"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -326,7 +355,8 @@ CREATE OR REPLACE FUNCTION search_label_annotation_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(annotation, label) AS (SELECT OLD.annotation, OLD.label)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"label_annotation"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -337,7 +367,8 @@ CREATE OR REPLACE FUNCTION search_label_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"label"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -348,7 +379,8 @@ CREATE OR REPLACE FUNCTION search_label_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"label"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -359,7 +391,8 @@ CREATE OR REPLACE FUNCTION search_label_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'delete', (
             WITH keys(gid) AS (SELECT OLD.gid)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"label"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -370,7 +403,8 @@ CREATE OR REPLACE FUNCTION search_place_annotation_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(annotation, place) AS (SELECT NEW.annotation, NEW.place)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"place_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"place_annotation"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -381,7 +415,8 @@ CREATE OR REPLACE FUNCTION search_place_annotation_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(annotation, place) AS (SELECT NEW.annotation, NEW.place)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"place_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"place_annotation"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -392,7 +427,8 @@ CREATE OR REPLACE FUNCTION search_place_annotation_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(annotation, place) AS (SELECT OLD.annotation, OLD.place)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"place_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"place_annotation"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -403,7 +439,8 @@ CREATE OR REPLACE FUNCTION search_place_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"place"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"place"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -414,7 +451,8 @@ CREATE OR REPLACE FUNCTION search_place_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"place"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"place"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -425,7 +463,8 @@ CREATE OR REPLACE FUNCTION search_place_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'delete', (
             WITH keys(gid) AS (SELECT OLD.gid)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"place"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"place"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -436,7 +475,8 @@ CREATE OR REPLACE FUNCTION search_recording_annotation_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(annotation, recording) AS (SELECT NEW.annotation, NEW.recording)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"recording_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"recording_annotation"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -447,7 +487,8 @@ CREATE OR REPLACE FUNCTION search_recording_annotation_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(annotation, recording) AS (SELECT NEW.annotation, NEW.recording)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"recording_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"recording_annotation"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -458,7 +499,8 @@ CREATE OR REPLACE FUNCTION search_recording_annotation_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(annotation, recording) AS (SELECT OLD.annotation, OLD.recording)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"recording_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"recording_annotation"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -469,7 +511,8 @@ CREATE OR REPLACE FUNCTION search_recording_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"recording"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"recording"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -480,7 +523,8 @@ CREATE OR REPLACE FUNCTION search_recording_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"recording"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"recording"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -491,7 +535,8 @@ CREATE OR REPLACE FUNCTION search_recording_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'delete', (
             WITH keys(gid) AS (SELECT OLD.gid)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"recording"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"recording"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -502,7 +547,8 @@ CREATE OR REPLACE FUNCTION search_release_annotation_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(annotation, release) AS (SELECT NEW.annotation, NEW.release)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_annotation"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -513,7 +559,8 @@ CREATE OR REPLACE FUNCTION search_release_annotation_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(annotation, release) AS (SELECT NEW.annotation, NEW.release)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_annotation"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -524,7 +571,8 @@ CREATE OR REPLACE FUNCTION search_release_annotation_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(annotation, release) AS (SELECT OLD.annotation, OLD.release)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_annotation"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -535,7 +583,8 @@ CREATE OR REPLACE FUNCTION search_release_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -546,7 +595,8 @@ CREATE OR REPLACE FUNCTION search_release_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -557,7 +607,8 @@ CREATE OR REPLACE FUNCTION search_release_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'delete', (
             WITH keys(gid) AS (SELECT OLD.gid)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -568,7 +619,8 @@ CREATE OR REPLACE FUNCTION search_release_group_annotation_insert() RETURNS trig
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(annotation, release_group) AS (SELECT NEW.annotation, NEW.release_group)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_annotation"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -579,7 +631,8 @@ CREATE OR REPLACE FUNCTION search_release_group_annotation_update() RETURNS trig
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(annotation, release_group) AS (SELECT NEW.annotation, NEW.release_group)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_annotation"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -590,7 +643,8 @@ CREATE OR REPLACE FUNCTION search_release_group_annotation_delete() RETURNS trig
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(annotation, release_group) AS (SELECT OLD.annotation, OLD.release_group)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_annotation"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -601,7 +655,8 @@ CREATE OR REPLACE FUNCTION search_release_group_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -612,7 +667,8 @@ CREATE OR REPLACE FUNCTION search_release_group_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -623,7 +679,8 @@ CREATE OR REPLACE FUNCTION search_release_group_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'delete', (
             WITH keys(gid) AS (SELECT OLD.gid)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -634,7 +691,8 @@ CREATE OR REPLACE FUNCTION search_series_annotation_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(annotation, series) AS (SELECT NEW.annotation, NEW.series)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"series_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"series_annotation"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -645,7 +703,8 @@ CREATE OR REPLACE FUNCTION search_series_annotation_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(annotation, series) AS (SELECT NEW.annotation, NEW.series)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"series_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"series_annotation"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -656,7 +715,8 @@ CREATE OR REPLACE FUNCTION search_series_annotation_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(annotation, series) AS (SELECT OLD.annotation, OLD.series)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"series_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"series_annotation"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -667,7 +727,8 @@ CREATE OR REPLACE FUNCTION search_series_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"series"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"series"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -678,7 +739,8 @@ CREATE OR REPLACE FUNCTION search_series_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"series"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"series"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -689,7 +751,8 @@ CREATE OR REPLACE FUNCTION search_series_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'delete', (
             WITH keys(gid) AS (SELECT OLD.gid)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"series"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"series"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -700,7 +763,8 @@ CREATE OR REPLACE FUNCTION search_work_annotation_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(annotation, work) AS (SELECT NEW.annotation, NEW.work)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"work_annotation"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -711,7 +775,8 @@ CREATE OR REPLACE FUNCTION search_work_annotation_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(annotation, work) AS (SELECT NEW.annotation, NEW.work)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"work_annotation"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -722,7 +787,8 @@ CREATE OR REPLACE FUNCTION search_work_annotation_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(annotation, work) AS (SELECT OLD.annotation, OLD.work)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work_annotation"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"work_annotation"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -733,7 +799,8 @@ CREATE OR REPLACE FUNCTION search_work_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"work"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -744,7 +811,8 @@ CREATE OR REPLACE FUNCTION search_work_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"work"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -755,7 +823,8 @@ CREATE OR REPLACE FUNCTION search_work_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'delete', (
             WITH keys(gid) AS (SELECT OLD.gid)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"work"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -766,7 +835,8 @@ CREATE OR REPLACE FUNCTION search_area_alias_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(area, id, type) AS (SELECT NEW.area, NEW.id, NEW.type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"area_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"area_alias"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -777,7 +847,8 @@ CREATE OR REPLACE FUNCTION search_area_alias_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(area, id, type) AS (SELECT NEW.area, NEW.id, NEW.type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"area_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"area_alias"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -788,7 +859,8 @@ CREATE OR REPLACE FUNCTION search_area_alias_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(area, id, type) AS (SELECT OLD.area, OLD.id, OLD.type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"area_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"area_alias"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -799,7 +871,8 @@ CREATE OR REPLACE FUNCTION search_iso_3166_1_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(area, code) AS (SELECT NEW.area, NEW.code)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_1"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_1"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -810,7 +883,8 @@ CREATE OR REPLACE FUNCTION search_iso_3166_1_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(area, code) AS (SELECT NEW.area, NEW.code)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_1"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_1"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -821,7 +895,8 @@ CREATE OR REPLACE FUNCTION search_iso_3166_1_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(area, code) AS (SELECT OLD.area, OLD.code)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_1"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_1"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -832,7 +907,8 @@ CREATE OR REPLACE FUNCTION search_iso_3166_2_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(area, code) AS (SELECT NEW.area, NEW.code)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_2"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_2"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -843,7 +919,8 @@ CREATE OR REPLACE FUNCTION search_iso_3166_2_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(area, code) AS (SELECT NEW.area, NEW.code)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_2"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_2"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -854,7 +931,8 @@ CREATE OR REPLACE FUNCTION search_iso_3166_2_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(area, code) AS (SELECT OLD.area, OLD.code)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_2"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_2"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -865,7 +943,8 @@ CREATE OR REPLACE FUNCTION search_iso_3166_3_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(area, code) AS (SELECT NEW.area, NEW.code)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_3"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_3"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -876,7 +955,8 @@ CREATE OR REPLACE FUNCTION search_iso_3166_3_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(area, code) AS (SELECT NEW.area, NEW.code)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_3"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_3"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -887,7 +967,8 @@ CREATE OR REPLACE FUNCTION search_iso_3166_3_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(area, code) AS (SELECT OLD.area, OLD.code)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_3"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"iso_3166_3"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -898,7 +979,8 @@ CREATE OR REPLACE FUNCTION search_area_tag_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(area, tag) AS (SELECT NEW.area, NEW.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"area_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"area_tag"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -909,7 +991,8 @@ CREATE OR REPLACE FUNCTION search_area_tag_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(area, tag) AS (SELECT NEW.area, NEW.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"area_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"area_tag"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -920,7 +1003,8 @@ CREATE OR REPLACE FUNCTION search_area_tag_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(area, tag) AS (SELECT OLD.area, OLD.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"area_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"area_tag"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -931,7 +1015,8 @@ CREATE OR REPLACE FUNCTION search_tag_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"tag"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -942,7 +1027,8 @@ CREATE OR REPLACE FUNCTION search_tag_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"tag"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -953,7 +1039,8 @@ CREATE OR REPLACE FUNCTION search_tag_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'delete', (
             WITH keys(id) AS (SELECT OLD.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"tag"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -964,7 +1051,8 @@ CREATE OR REPLACE FUNCTION search_area_type_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"area_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"area_type"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -975,7 +1063,8 @@ CREATE OR REPLACE FUNCTION search_area_type_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"area_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"area_type"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -986,7 +1075,8 @@ CREATE OR REPLACE FUNCTION search_area_type_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"area_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"area_type"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -997,7 +1087,8 @@ CREATE OR REPLACE FUNCTION search_artist_alias_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(artist, id, type) AS (SELECT NEW.artist, NEW.id, NEW.type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_alias"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1008,7 +1099,8 @@ CREATE OR REPLACE FUNCTION search_artist_alias_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(artist, id, type) AS (SELECT NEW.artist, NEW.id, NEW.type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_alias"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1019,7 +1111,8 @@ CREATE OR REPLACE FUNCTION search_artist_alias_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(artist, id, type) AS (SELECT OLD.artist, OLD.id, OLD.type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_alias"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1030,7 +1123,8 @@ CREATE OR REPLACE FUNCTION search_gender_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"gender"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"gender"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1041,7 +1135,8 @@ CREATE OR REPLACE FUNCTION search_gender_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"gender"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"gender"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1052,7 +1147,8 @@ CREATE OR REPLACE FUNCTION search_gender_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"gender"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"gender"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1063,7 +1159,8 @@ CREATE OR REPLACE FUNCTION search_artist_ipi_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(artist, ipi) AS (SELECT NEW.artist, NEW.ipi)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_ipi"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_ipi"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1074,7 +1171,8 @@ CREATE OR REPLACE FUNCTION search_artist_ipi_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(artist, ipi) AS (SELECT NEW.artist, NEW.ipi)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_ipi"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_ipi"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1085,7 +1183,8 @@ CREATE OR REPLACE FUNCTION search_artist_ipi_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(artist, ipi) AS (SELECT OLD.artist, OLD.ipi)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_ipi"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_ipi"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1096,7 +1195,8 @@ CREATE OR REPLACE FUNCTION search_artist_isni_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(artist, isni) AS (SELECT NEW.artist, NEW.isni)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_isni"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_isni"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1107,7 +1207,8 @@ CREATE OR REPLACE FUNCTION search_artist_isni_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(artist, isni) AS (SELECT NEW.artist, NEW.isni)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_isni"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_isni"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1118,7 +1219,8 @@ CREATE OR REPLACE FUNCTION search_artist_isni_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(artist, isni) AS (SELECT OLD.artist, OLD.isni)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_isni"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_isni"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1129,7 +1231,8 @@ CREATE OR REPLACE FUNCTION search_artist_tag_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(artist, tag) AS (SELECT NEW.artist, NEW.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_tag"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1140,7 +1243,8 @@ CREATE OR REPLACE FUNCTION search_artist_tag_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(artist, tag) AS (SELECT NEW.artist, NEW.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_tag"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1151,7 +1255,8 @@ CREATE OR REPLACE FUNCTION search_artist_tag_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(artist, tag) AS (SELECT OLD.artist, OLD.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_tag"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1162,7 +1267,8 @@ CREATE OR REPLACE FUNCTION search_artist_credit_name_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(artist, artist_credit, position) AS (SELECT NEW.artist, NEW.artist_credit, NEW.position)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_credit_name"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_credit_name"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1173,7 +1279,8 @@ CREATE OR REPLACE FUNCTION search_artist_credit_name_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(artist, artist_credit, position) AS (SELECT NEW.artist, NEW.artist_credit, NEW.position)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_credit_name"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_credit_name"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1184,7 +1291,8 @@ CREATE OR REPLACE FUNCTION search_artist_credit_name_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(artist, artist_credit, position) AS (SELECT OLD.artist, OLD.artist_credit, OLD.position)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_credit_name"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_credit_name"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1195,7 +1303,8 @@ CREATE OR REPLACE FUNCTION search_artist_credit_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_credit"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_credit"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1206,7 +1315,8 @@ CREATE OR REPLACE FUNCTION search_artist_credit_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_credit"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_credit"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1217,7 +1327,8 @@ CREATE OR REPLACE FUNCTION search_artist_credit_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT OLD.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_credit"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_credit"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1228,7 +1339,8 @@ CREATE OR REPLACE FUNCTION search_artist_type_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_type"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1239,7 +1351,8 @@ CREATE OR REPLACE FUNCTION search_artist_type_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_type"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1250,7 +1363,8 @@ CREATE OR REPLACE FUNCTION search_artist_type_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"artist_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"artist_type"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1261,7 +1375,8 @@ CREATE OR REPLACE FUNCTION search_release_raw_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_raw"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_raw"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1272,7 +1387,8 @@ CREATE OR REPLACE FUNCTION search_release_raw_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_raw"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_raw"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1283,7 +1399,8 @@ CREATE OR REPLACE FUNCTION search_release_raw_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'delete', (
             WITH keys(id) AS (SELECT OLD.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_raw"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_raw"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1294,7 +1411,8 @@ CREATE OR REPLACE FUNCTION search_cdtoc_raw_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, release) AS (SELECT NEW.id, NEW.release)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"cdtoc_raw"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"cdtoc_raw"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1305,7 +1423,8 @@ CREATE OR REPLACE FUNCTION search_cdtoc_raw_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, release) AS (SELECT NEW.id, NEW.release)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"cdtoc_raw"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"cdtoc_raw"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1316,7 +1435,8 @@ CREATE OR REPLACE FUNCTION search_cdtoc_raw_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, release) AS (SELECT OLD.id, OLD.release)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"cdtoc_raw"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"cdtoc_raw"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1327,7 +1447,8 @@ CREATE OR REPLACE FUNCTION search_editor_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"editor"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"editor"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1338,7 +1459,8 @@ CREATE OR REPLACE FUNCTION search_editor_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"editor"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"editor"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1349,7 +1471,8 @@ CREATE OR REPLACE FUNCTION search_editor_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'delete', (
             WITH keys(id) AS (SELECT OLD.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"editor"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"editor"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1360,7 +1483,8 @@ CREATE OR REPLACE FUNCTION search_event_alias_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(event, id, type) AS (SELECT NEW.event, NEW.id, NEW.type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"event_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"event_alias"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1371,7 +1495,8 @@ CREATE OR REPLACE FUNCTION search_event_alias_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(event, id, type) AS (SELECT NEW.event, NEW.id, NEW.type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"event_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"event_alias"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1382,7 +1507,8 @@ CREATE OR REPLACE FUNCTION search_event_alias_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(event, id, type) AS (SELECT OLD.event, OLD.id, OLD.type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"event_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"event_alias"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1393,7 +1519,8 @@ CREATE OR REPLACE FUNCTION search_l_area_event_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_area_event"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"l_area_event"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1404,7 +1531,8 @@ CREATE OR REPLACE FUNCTION search_l_area_event_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_area_event"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"l_area_event"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1415,7 +1543,8 @@ CREATE OR REPLACE FUNCTION search_l_area_event_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(entity0, entity1, id, link) AS (SELECT OLD.entity0, OLD.entity1, OLD.id, OLD.link)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_area_event"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"l_area_event"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1426,7 +1555,8 @@ CREATE OR REPLACE FUNCTION search_l_artist_event_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_event"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_event"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1437,7 +1567,8 @@ CREATE OR REPLACE FUNCTION search_l_artist_event_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_event"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_event"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1448,7 +1579,8 @@ CREATE OR REPLACE FUNCTION search_l_artist_event_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(entity0, entity1, id, link) AS (SELECT OLD.entity0, OLD.entity1, OLD.id, OLD.link)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_event"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_event"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1459,7 +1591,8 @@ CREATE OR REPLACE FUNCTION search_l_event_place_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_event_place"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"l_event_place"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1470,7 +1603,8 @@ CREATE OR REPLACE FUNCTION search_l_event_place_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_event_place"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"l_event_place"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1481,7 +1615,8 @@ CREATE OR REPLACE FUNCTION search_l_event_place_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(entity0, entity1, id, link) AS (SELECT OLD.entity0, OLD.entity1, OLD.id, OLD.link)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_event_place"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"l_event_place"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1492,7 +1627,8 @@ CREATE OR REPLACE FUNCTION search_event_tag_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(event, tag) AS (SELECT NEW.event, NEW.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"event_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"event_tag"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1503,7 +1639,8 @@ CREATE OR REPLACE FUNCTION search_event_tag_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(event, tag) AS (SELECT NEW.event, NEW.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"event_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"event_tag"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1514,7 +1651,8 @@ CREATE OR REPLACE FUNCTION search_event_tag_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(event, tag) AS (SELECT OLD.event, OLD.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"event_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"event_tag"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1525,7 +1663,8 @@ CREATE OR REPLACE FUNCTION search_event_type_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"event_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"event_type"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1536,7 +1675,8 @@ CREATE OR REPLACE FUNCTION search_event_type_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"event_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"event_type"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1547,7 +1687,8 @@ CREATE OR REPLACE FUNCTION search_event_type_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"event_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"event_type"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1558,7 +1699,8 @@ CREATE OR REPLACE FUNCTION search_instrument_alias_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, instrument, type) AS (SELECT NEW.id, NEW.instrument, NEW.type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"instrument_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"instrument_alias"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1569,7 +1711,8 @@ CREATE OR REPLACE FUNCTION search_instrument_alias_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, instrument, type) AS (SELECT NEW.id, NEW.instrument, NEW.type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"instrument_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"instrument_alias"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1580,7 +1723,8 @@ CREATE OR REPLACE FUNCTION search_instrument_alias_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, instrument, type) AS (SELECT OLD.id, OLD.instrument, OLD.type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"instrument_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"instrument_alias"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1591,7 +1735,8 @@ CREATE OR REPLACE FUNCTION search_instrument_tag_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(instrument, tag) AS (SELECT NEW.instrument, NEW.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"instrument_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"instrument_tag"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1602,7 +1747,8 @@ CREATE OR REPLACE FUNCTION search_instrument_tag_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(instrument, tag) AS (SELECT NEW.instrument, NEW.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"instrument_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"instrument_tag"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1613,7 +1759,8 @@ CREATE OR REPLACE FUNCTION search_instrument_tag_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(instrument, tag) AS (SELECT OLD.instrument, OLD.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"instrument_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"instrument_tag"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1624,7 +1771,8 @@ CREATE OR REPLACE FUNCTION search_instrument_type_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"instrument_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"instrument_type"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1635,7 +1783,8 @@ CREATE OR REPLACE FUNCTION search_instrument_type_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"instrument_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"instrument_type"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1646,7 +1795,8 @@ CREATE OR REPLACE FUNCTION search_instrument_type_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"instrument_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"instrument_type"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1657,7 +1807,8 @@ CREATE OR REPLACE FUNCTION search_label_alias_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, label, type) AS (SELECT NEW.id, NEW.label, NEW.type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"label_alias"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1668,7 +1819,8 @@ CREATE OR REPLACE FUNCTION search_label_alias_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, label, type) AS (SELECT NEW.id, NEW.label, NEW.type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"label_alias"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1679,7 +1831,8 @@ CREATE OR REPLACE FUNCTION search_label_alias_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, label, type) AS (SELECT OLD.id, OLD.label, OLD.type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"label_alias"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1690,7 +1843,8 @@ CREATE OR REPLACE FUNCTION search_label_ipi_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(ipi, label) AS (SELECT NEW.ipi, NEW.label)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label_ipi"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"label_ipi"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1701,7 +1855,8 @@ CREATE OR REPLACE FUNCTION search_label_ipi_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(ipi, label) AS (SELECT NEW.ipi, NEW.label)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label_ipi"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"label_ipi"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1712,7 +1867,8 @@ CREATE OR REPLACE FUNCTION search_label_ipi_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(ipi, label) AS (SELECT OLD.ipi, OLD.label)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label_ipi"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"label_ipi"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1723,7 +1879,8 @@ CREATE OR REPLACE FUNCTION search_label_tag_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(label, tag) AS (SELECT NEW.label, NEW.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"label_tag"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1734,7 +1891,8 @@ CREATE OR REPLACE FUNCTION search_label_tag_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(label, tag) AS (SELECT NEW.label, NEW.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"label_tag"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1745,7 +1903,8 @@ CREATE OR REPLACE FUNCTION search_label_tag_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(label, tag) AS (SELECT OLD.label, OLD.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"label_tag"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1756,7 +1915,8 @@ CREATE OR REPLACE FUNCTION search_label_type_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"label_type"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1767,7 +1927,8 @@ CREATE OR REPLACE FUNCTION search_label_type_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"label_type"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1778,7 +1939,8 @@ CREATE OR REPLACE FUNCTION search_label_type_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"label_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"label_type"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1789,7 +1951,8 @@ CREATE OR REPLACE FUNCTION search_place_alias_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, place, type) AS (SELECT NEW.id, NEW.place, NEW.type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"place_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"place_alias"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1800,7 +1963,8 @@ CREATE OR REPLACE FUNCTION search_place_alias_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, place, type) AS (SELECT NEW.id, NEW.place, NEW.type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"place_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"place_alias"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1811,7 +1975,8 @@ CREATE OR REPLACE FUNCTION search_place_alias_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, place, type) AS (SELECT OLD.id, OLD.place, OLD.type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"place_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"place_alias"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1822,7 +1987,8 @@ CREATE OR REPLACE FUNCTION search_place_type_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"place_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"place_type"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1833,7 +1999,8 @@ CREATE OR REPLACE FUNCTION search_place_type_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"place_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"place_type"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1844,7 +2011,8 @@ CREATE OR REPLACE FUNCTION search_place_type_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"place_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"place_type"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1855,7 +2023,8 @@ CREATE OR REPLACE FUNCTION search_track_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(artist_credit, id, medium, recording) AS (SELECT NEW.artist_credit, NEW.id, NEW.medium, NEW.recording)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"track"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"track"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1866,7 +2035,8 @@ CREATE OR REPLACE FUNCTION search_track_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(artist_credit, id, medium, recording) AS (SELECT NEW.artist_credit, NEW.id, NEW.medium, NEW.recording)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"track"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"track"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1877,7 +2047,8 @@ CREATE OR REPLACE FUNCTION search_track_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(artist_credit, id, medium, recording) AS (SELECT OLD.artist_credit, OLD.id, OLD.medium, OLD.recording)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"track"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"track"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1888,7 +2059,8 @@ CREATE OR REPLACE FUNCTION search_medium_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(format, id, release) AS (SELECT NEW.format, NEW.id, NEW.release)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"medium"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"medium"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1899,7 +2071,8 @@ CREATE OR REPLACE FUNCTION search_medium_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(format, id, release) AS (SELECT NEW.format, NEW.id, NEW.release)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"medium"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"medium"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1910,7 +2083,8 @@ CREATE OR REPLACE FUNCTION search_medium_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(format, id, release) AS (SELECT OLD.format, OLD.id, OLD.release)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"medium"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"medium"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1921,7 +2095,8 @@ CREATE OR REPLACE FUNCTION search_release_country_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(country, release) AS (SELECT NEW.country, NEW.release)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_country"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_country"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1932,7 +2107,8 @@ CREATE OR REPLACE FUNCTION search_release_country_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(country, release) AS (SELECT NEW.country, NEW.release)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_country"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_country"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1943,7 +2119,8 @@ CREATE OR REPLACE FUNCTION search_release_country_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(country, release) AS (SELECT OLD.country, OLD.release)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_country"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_country"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1954,7 +2131,8 @@ CREATE OR REPLACE FUNCTION search_country_area_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(area) AS (SELECT NEW.area)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"country_area"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"country_area"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1965,7 +2143,8 @@ CREATE OR REPLACE FUNCTION search_country_area_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(area) AS (SELECT NEW.area)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"country_area"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"country_area"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1976,7 +2155,8 @@ CREATE OR REPLACE FUNCTION search_country_area_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(area) AS (SELECT OLD.area)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"country_area"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"country_area"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -1987,7 +2167,8 @@ CREATE OR REPLACE FUNCTION search_medium_format_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"medium_format"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"medium_format"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -1998,7 +2179,8 @@ CREATE OR REPLACE FUNCTION search_medium_format_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"medium_format"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"medium_format"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2009,7 +2191,8 @@ CREATE OR REPLACE FUNCTION search_medium_format_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"medium_format"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"medium_format"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2020,7 +2203,8 @@ CREATE OR REPLACE FUNCTION search_isrc_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, recording) AS (SELECT NEW.id, NEW.recording)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"isrc"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"isrc"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2031,7 +2215,8 @@ CREATE OR REPLACE FUNCTION search_isrc_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, recording) AS (SELECT NEW.id, NEW.recording)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"isrc"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"isrc"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2042,7 +2227,8 @@ CREATE OR REPLACE FUNCTION search_isrc_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, recording) AS (SELECT OLD.id, OLD.recording)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"isrc"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"isrc"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2053,7 +2239,8 @@ CREATE OR REPLACE FUNCTION search_release_group_primary_type_insert() RETURNS tr
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group_primary_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_primary_type"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2064,7 +2251,8 @@ CREATE OR REPLACE FUNCTION search_release_group_primary_type_update() RETURNS tr
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group_primary_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_primary_type"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2075,7 +2263,8 @@ CREATE OR REPLACE FUNCTION search_release_group_primary_type_delete() RETURNS tr
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group_primary_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_primary_type"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2086,7 +2275,8 @@ CREATE OR REPLACE FUNCTION search_release_group_secondary_type_join_insert() RET
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(release_group, secondary_type) AS (SELECT NEW.release_group, NEW.secondary_type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group_secondary_type_join"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_secondary_type_join"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2097,7 +2287,8 @@ CREATE OR REPLACE FUNCTION search_release_group_secondary_type_join_update() RET
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(release_group, secondary_type) AS (SELECT NEW.release_group, NEW.secondary_type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group_secondary_type_join"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_secondary_type_join"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2108,7 +2299,8 @@ CREATE OR REPLACE FUNCTION search_release_group_secondary_type_join_delete() RET
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(release_group, secondary_type) AS (SELECT OLD.release_group, OLD.secondary_type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group_secondary_type_join"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_secondary_type_join"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2119,7 +2311,8 @@ CREATE OR REPLACE FUNCTION search_release_group_secondary_type_insert() RETURNS 
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group_secondary_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_secondary_type"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2130,7 +2323,8 @@ CREATE OR REPLACE FUNCTION search_release_group_secondary_type_update() RETURNS 
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group_secondary_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_secondary_type"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2141,7 +2335,8 @@ CREATE OR REPLACE FUNCTION search_release_group_secondary_type_delete() RETURNS 
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group_secondary_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_secondary_type"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2152,7 +2347,8 @@ CREATE OR REPLACE FUNCTION search_release_status_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_status"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_status"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2163,7 +2359,8 @@ CREATE OR REPLACE FUNCTION search_release_status_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_status"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_status"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2174,7 +2371,8 @@ CREATE OR REPLACE FUNCTION search_release_status_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_status"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_status"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2185,7 +2383,8 @@ CREATE OR REPLACE FUNCTION search_recording_tag_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(recording, tag) AS (SELECT NEW.recording, NEW.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"recording_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"recording_tag"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2196,7 +2395,8 @@ CREATE OR REPLACE FUNCTION search_recording_tag_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(recording, tag) AS (SELECT NEW.recording, NEW.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"recording_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"recording_tag"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2207,7 +2407,8 @@ CREATE OR REPLACE FUNCTION search_recording_tag_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(recording, tag) AS (SELECT OLD.recording, OLD.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"recording_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"recording_tag"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2218,7 +2419,8 @@ CREATE OR REPLACE FUNCTION search_release_meta_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_meta"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_meta"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2229,7 +2431,8 @@ CREATE OR REPLACE FUNCTION search_release_meta_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_meta"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_meta"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2240,7 +2443,8 @@ CREATE OR REPLACE FUNCTION search_release_meta_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT OLD.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_meta"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_meta"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2251,7 +2455,8 @@ CREATE OR REPLACE FUNCTION search_release_label_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, label, release) AS (SELECT NEW.id, NEW.label, NEW.release)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_label"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_label"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2262,7 +2467,8 @@ CREATE OR REPLACE FUNCTION search_release_label_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, label, release) AS (SELECT NEW.id, NEW.label, NEW.release)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_label"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_label"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2273,7 +2479,8 @@ CREATE OR REPLACE FUNCTION search_release_label_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, label, release) AS (SELECT OLD.id, OLD.label, OLD.release)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_label"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_label"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2284,7 +2491,8 @@ CREATE OR REPLACE FUNCTION search_medium_cdtoc_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(cdtoc, id, medium) AS (SELECT NEW.cdtoc, NEW.id, NEW.medium)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"medium_cdtoc"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"medium_cdtoc"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2295,7 +2503,8 @@ CREATE OR REPLACE FUNCTION search_medium_cdtoc_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(cdtoc, id, medium) AS (SELECT NEW.cdtoc, NEW.id, NEW.medium)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"medium_cdtoc"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"medium_cdtoc"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2306,7 +2515,8 @@ CREATE OR REPLACE FUNCTION search_medium_cdtoc_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(cdtoc, id, medium) AS (SELECT OLD.cdtoc, OLD.id, OLD.medium)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"medium_cdtoc"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"medium_cdtoc"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2317,7 +2527,8 @@ CREATE OR REPLACE FUNCTION search_language_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"language"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"language"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2328,7 +2539,8 @@ CREATE OR REPLACE FUNCTION search_language_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"language"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"language"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2339,7 +2551,8 @@ CREATE OR REPLACE FUNCTION search_language_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT OLD.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"language"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"language"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2350,7 +2563,8 @@ CREATE OR REPLACE FUNCTION search_script_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"script"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"script"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2361,7 +2575,8 @@ CREATE OR REPLACE FUNCTION search_script_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"script"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"script"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2372,7 +2587,8 @@ CREATE OR REPLACE FUNCTION search_script_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT OLD.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"script"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"script"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2383,7 +2599,8 @@ CREATE OR REPLACE FUNCTION search_release_tag_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(release, tag) AS (SELECT NEW.release, NEW.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_tag"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2394,7 +2611,8 @@ CREATE OR REPLACE FUNCTION search_release_tag_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(release, tag) AS (SELECT NEW.release, NEW.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_tag"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2405,7 +2623,8 @@ CREATE OR REPLACE FUNCTION search_release_tag_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(release, tag) AS (SELECT OLD.release, OLD.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_tag"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2416,7 +2635,8 @@ CREATE OR REPLACE FUNCTION search_release_group_tag_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(release_group, tag) AS (SELECT NEW.release_group, NEW.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_tag"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2427,7 +2647,8 @@ CREATE OR REPLACE FUNCTION search_release_group_tag_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(release_group, tag) AS (SELECT NEW.release_group, NEW.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_tag"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2438,7 +2659,8 @@ CREATE OR REPLACE FUNCTION search_release_group_tag_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(release_group, tag) AS (SELECT OLD.release_group, OLD.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"release_group_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_tag"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2449,7 +2671,8 @@ CREATE OR REPLACE FUNCTION search_series_alias_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, series, type) AS (SELECT NEW.id, NEW.series, NEW.type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"series_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"series_alias"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2460,7 +2683,8 @@ CREATE OR REPLACE FUNCTION search_series_alias_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, series, type) AS (SELECT NEW.id, NEW.series, NEW.type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"series_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"series_alias"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2471,7 +2695,8 @@ CREATE OR REPLACE FUNCTION search_series_alias_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, series, type) AS (SELECT OLD.id, OLD.series, OLD.type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"series_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"series_alias"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2482,7 +2707,8 @@ CREATE OR REPLACE FUNCTION search_link_attribute_type_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, parent, root) AS (SELECT NEW.id, NEW.parent, NEW.root)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"link_attribute_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"link_attribute_type"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2493,7 +2719,8 @@ CREATE OR REPLACE FUNCTION search_link_attribute_type_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent, root) AS (SELECT NEW.id, NEW.parent, NEW.root)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"link_attribute_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"link_attribute_type"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2504,7 +2731,8 @@ CREATE OR REPLACE FUNCTION search_link_attribute_type_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent, root) AS (SELECT OLD.id, OLD.parent, OLD.root)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"link_attribute_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"link_attribute_type"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2515,7 +2743,8 @@ CREATE OR REPLACE FUNCTION search_series_tag_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(series, tag) AS (SELECT NEW.series, NEW.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"series_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"series_tag"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2526,7 +2755,8 @@ CREATE OR REPLACE FUNCTION search_series_tag_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(series, tag) AS (SELECT NEW.series, NEW.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"series_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"series_tag"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2537,7 +2767,8 @@ CREATE OR REPLACE FUNCTION search_series_tag_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(series, tag) AS (SELECT OLD.series, OLD.tag)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"series_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"series_tag"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2548,7 +2779,8 @@ CREATE OR REPLACE FUNCTION search_series_type_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"series_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"series_type"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2559,7 +2791,8 @@ CREATE OR REPLACE FUNCTION search_series_type_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"series_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"series_type"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2570,7 +2803,8 @@ CREATE OR REPLACE FUNCTION search_series_type_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"series_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"series_type"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2581,7 +2815,8 @@ CREATE OR REPLACE FUNCTION search_url_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"url"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"url"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2592,7 +2827,8 @@ CREATE OR REPLACE FUNCTION search_url_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"url"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"url"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2603,7 +2839,8 @@ CREATE OR REPLACE FUNCTION search_url_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'delete', (
             WITH keys(gid) AS (SELECT OLD.gid)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"url"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"url"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2614,7 +2851,8 @@ CREATE OR REPLACE FUNCTION search_l_artist_url_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_url"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_url"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2625,7 +2863,8 @@ CREATE OR REPLACE FUNCTION search_l_artist_url_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_url"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_url"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2636,7 +2875,8 @@ CREATE OR REPLACE FUNCTION search_l_artist_url_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(entity0, entity1, id, link) AS (SELECT OLD.entity0, OLD.entity1, OLD.id, OLD.link)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_url"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_url"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2647,7 +2887,8 @@ CREATE OR REPLACE FUNCTION search_link_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, link_type) AS (SELECT NEW.id, NEW.link_type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"link"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"link"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2658,7 +2899,8 @@ CREATE OR REPLACE FUNCTION search_link_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, link_type) AS (SELECT NEW.id, NEW.link_type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"link"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"link"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2669,7 +2911,8 @@ CREATE OR REPLACE FUNCTION search_link_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, link_type) AS (SELECT OLD.id, OLD.link_type)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"link"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"link"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2680,7 +2923,8 @@ CREATE OR REPLACE FUNCTION search_link_type_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"link_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"link_type"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2691,7 +2935,8 @@ CREATE OR REPLACE FUNCTION search_link_type_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"link_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"link_type"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2702,7 +2947,8 @@ CREATE OR REPLACE FUNCTION search_link_type_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"link_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"link_type"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2713,7 +2959,8 @@ CREATE OR REPLACE FUNCTION search_work_alias_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, type, work) AS (SELECT NEW.id, NEW.type, NEW.work)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"work_alias"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2724,7 +2971,8 @@ CREATE OR REPLACE FUNCTION search_work_alias_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, type, work) AS (SELECT NEW.id, NEW.type, NEW.work)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"work_alias"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2735,7 +2983,8 @@ CREATE OR REPLACE FUNCTION search_work_alias_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, type, work) AS (SELECT OLD.id, OLD.type, OLD.work)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work_alias"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"work_alias"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2746,7 +2995,8 @@ CREATE OR REPLACE FUNCTION search_l_artist_work_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_work"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_work"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2757,7 +3007,8 @@ CREATE OR REPLACE FUNCTION search_l_artist_work_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_work"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_work"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2768,7 +3019,8 @@ CREATE OR REPLACE FUNCTION search_l_artist_work_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(entity0, entity1, id, link) AS (SELECT OLD.entity0, OLD.entity1, OLD.id, OLD.link)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_work"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"l_artist_work"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2779,7 +3031,8 @@ CREATE OR REPLACE FUNCTION search_iswc_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, work) AS (SELECT NEW.id, NEW.work)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iswc"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"iswc"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2790,7 +3043,8 @@ CREATE OR REPLACE FUNCTION search_iswc_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, work) AS (SELECT NEW.id, NEW.work)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iswc"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"iswc"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2801,7 +3055,8 @@ CREATE OR REPLACE FUNCTION search_iswc_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, work) AS (SELECT OLD.id, OLD.work)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"iswc"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"iswc"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2812,7 +3067,8 @@ CREATE OR REPLACE FUNCTION search_work_language_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(language, work) AS (SELECT NEW.language, NEW.work)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work_language"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"work_language"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2823,7 +3079,8 @@ CREATE OR REPLACE FUNCTION search_work_language_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(language, work) AS (SELECT NEW.language, NEW.work)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work_language"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"work_language"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2834,7 +3091,8 @@ CREATE OR REPLACE FUNCTION search_work_language_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(language, work) AS (SELECT OLD.language, OLD.work)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work_language"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"work_language"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2845,7 +3103,8 @@ CREATE OR REPLACE FUNCTION search_l_recording_work_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_recording_work"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"l_recording_work"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2856,7 +3115,8 @@ CREATE OR REPLACE FUNCTION search_l_recording_work_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(entity0, entity1, id, link) AS (SELECT NEW.entity0, NEW.entity1, NEW.id, NEW.link)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_recording_work"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"l_recording_work"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2867,7 +3127,8 @@ CREATE OR REPLACE FUNCTION search_l_recording_work_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(entity0, entity1, id, link) AS (SELECT OLD.entity0, OLD.entity1, OLD.id, OLD.link)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"l_recording_work"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"l_recording_work"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2878,7 +3139,8 @@ CREATE OR REPLACE FUNCTION search_work_tag_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(tag, work) AS (SELECT NEW.tag, NEW.work)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"work_tag"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2889,7 +3151,8 @@ CREATE OR REPLACE FUNCTION search_work_tag_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(tag, work) AS (SELECT NEW.tag, NEW.work)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"work_tag"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2900,7 +3163,8 @@ CREATE OR REPLACE FUNCTION search_work_tag_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(tag, work) AS (SELECT OLD.tag, OLD.work)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work_tag"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"work_tag"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;
@@ -2911,7 +3175,8 @@ CREATE OR REPLACE FUNCTION search_work_type_insert() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"work_type"'),
+                             '{_operation}', '"insert"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2922,7 +3187,8 @@ CREATE OR REPLACE FUNCTION search_work_type_update() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT NEW.id, NEW.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"work_type"'),
+                             '{_operation}', '"update"')::text FROM keys
         ));
     RETURN NEW;
 END;
@@ -2933,7 +3199,8 @@ CREATE OR REPLACE FUNCTION search_work_type_delete() RETURNS trigger
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, parent) AS (SELECT OLD.id, OLD.parent)
-            SELECT jsonb_set(to_jsonb(keys), '{_table}', '"work_type"')::text FROM keys
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"work_type"'),
+                             '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;
 END;

--- a/test/test_amqp_handler.py
+++ b/test/test_amqp_handler.py
@@ -108,6 +108,7 @@ class HandlerTest(AmqpTestCase):
             application_headers={},
         )
         self.message.delivery_tag = self.delivery_tag
+        self.message.delivery_info = {"routing_key": self.routing_key}
         self.handler.delete_callback(self.message, "search.delete")
 
         self.handler.cores[self.entity_type].delete.assert_called_once_with(entity_gid)


### PR DESCRIPTION
So currently when a non core entitiy is deleted, the currently `generate selection` tries to update all the related paths in `update_map` by creating a SQL query which is dependent on that particular deleted row being present eg - `select id from musicbrainz.area where musicbrainz.area.id in (select are from musicbrainz.area_alias where musicbrainz.area_alias.id in (:ids))` now the inner query returns nothing since those rows are deleted. 