### PR TITLE
Remove ref_count from the schema

### DIFF
--- a/sir/schema/__init__.py
+++ b/sir/schema/__init__.py
@@ -436,8 +436,6 @@ SearchArtist = E(modelext.CustomArtist, [
     F("ipi", "ipis.ipi"),
     F("isni", "isnis.isni"),
     F("tag", "tags.tag.name"),
-    F("ref_count", "artist_credit_names.artist_credit.ref_count",
-      transformfunc=sum),
     F("type", "type.name")
 ],
     1.5,


### PR DESCRIPTION
Ref count isn't used anywhere in the XML schema and including it in the
search schema caused the live indexer to reindex entities like VA
everytime their ref count increased. This meant reindex of 3 million+
documents. As such it was decided to remove this.