### PR TITLE
Initial port to Py3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ mbdata==2017.6.2
 mb-rngpy==2.7.1
 psycopg2==2.7.3
 retrying==1.3.3
-solrpy==0.9.7
+pysolr==3.7.0
 sqlalchemy==1.0.2
 requests==2.18.3
 raven==6.1.0

--- a/sir/schema/searchentities.py
+++ b/sir/schema/searchentities.py
@@ -255,6 +255,8 @@ class SearchEntity(object):
             if isinstance(tempvals, set) and len(tempvals) == 1:
                 tempvals = tempvals.pop()
             if tempvals is not None and tempvals:
+                if isinstance(tempvals, set):
+                    tempvals = list(tempvals)
                 data[fieldname] = tempvals
 
         if (config.CFG.getboolean("sir", "wscompat") and self.compatconverter is

--- a/sir/schema/searchentities.py
+++ b/sir/schema/searchentities.py
@@ -255,6 +255,8 @@ class SearchEntity(object):
             if isinstance(tempvals, set) and len(tempvals) == 1:
                 tempvals = tempvals.pop()
             if tempvals is not None and tempvals:
+                # TO-DO (samj1912): Remove this typecast once https://github.com/django-haystack/pysolr/pull/229
+                # is merged.
                 if isinstance(tempvals, set):
                     tempvals = list(tempvals)
                 data[fieldname] = tempvals

--- a/sir/util.py
+++ b/sir/util.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 import amqp
 import logging
-import solr
+import pysolr
 import urllib2
 
 from . import config
@@ -86,7 +86,7 @@ def solr_connection(core):
     urllib2.urlopen(ping_uri)
 
     logger.debug("Connection to the Solr core at %s", core_uri)
-    return solr.Solr(core_uri)
+    return pysolr.Solr(core_uri)
 
 
 def solr_version_check(core):

--- a/test/test_searchentities.py
+++ b/test/test_searchentities.py
@@ -26,7 +26,7 @@ class QueryResultToDictTest(unittest.TestCase):
         self.expected = {
             "id": 1,
             "c_bar": "foo",
-            "c_bar_trans": set(["foo", "yay"]),
+            "c_bar_trans": ["foo", "yay"],
         }
         c = models.C(id=2, bar="foo")
         self.val = models.B(id=1, c=c)


### PR DESCRIPTION
# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [x] Other
* **Describe this change in 1-2 sentences**:
Initial port to Py3. Since solrpy doesn't support py3.5+, we switch to pysolr. It also comes with its own benefit as we are able to take care of SOLR-33.
# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->
Port to py3 is essential for maintainability as py2 support stops in 2020. This also involves switching from solrpy to pysolr. pysolr also cleans control chars. before submitting to Solr so it should take care of SOLR-33.

* JIRA ticket: [SOLR-33](https://tickets.metabrainz.org/browse/SOLR-33)


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Updated solrpy to pysolr. Since pysolr does not support sets as an iterable, I had to convert the values from sets to list before sending to solr. I made a patch upstream to solr @https://github.com/django-haystack/pysolr/pull/229. We can remove the typecast once it gets merged.


