### PR TITLE
Move update to `last_message` at the end of processed instead of the …

### DIFF
--- a/sir/amqp/handler.py
+++ b/sir/amqp/handler.py
@@ -299,7 +299,6 @@ class Handler(object):
         if not self.pending_messages:
             return
         try:
-            self.last_message = time.time()
             live_index(self.pending_entities)
             if not indexing.PROCESS_FLAG.value:
                 # It might happen that the DB pool workers have
@@ -324,6 +323,7 @@ class Handler(object):
         finally:
             self.pending_messages = []
             self.pending_entities.clear()
+            self.last_message = time.time()
 
     def _index_data(self, core_name, id_list, extra_data=None):
         total_ids = len(id_list)


### PR DESCRIPTION


# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

If the message takes a lot of time to process, we keep processing a single message, instead of a batch.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Simple fix is to move the update to last_message at the end of process_messages instead of the start.
# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
