### PR TITLE
Add pending messages to the retry queue in case any of them fails.

### DIFF
--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -1,9 +1,11 @@
 import mock
 import unittest
 
-from multiprocessing import Queue
-from sir.indexing import queue_to_solr, send_data_to_solr
+import sir.indexing
 
+from multiprocessing import Queue
+from sir.indexing import queue_to_solr, send_data_to_solr, FAILED
+from pysolr import SolrError
 
 class QueueToSolrTest(unittest.TestCase):
     def setUp(self):
@@ -25,10 +27,31 @@ class QueueToSolrTest(unittest.TestCase):
 
 class SendDataToSolrTest(unittest.TestCase):
     def setUp(self):
-        self.solr_connection = mock.Mock()
+        self.solr_connection = mock.MagicMock()
+        self.solr_connection.add = mock.MagicMock()
 
     def test_normal_send(self):
         send_data_to_solr(self.solr_connection, [{"foo": "bar"}])
         expected = [mock.call([{"foo": "bar"}], commit=False)]
         calls = self.solr_connection.add.call_args_list
         self.assertEqual(calls, expected)
+
+    def test_fail_send(self):
+        self.solr_connection.add.side_effect = SolrError('Test Error')
+        self.assertFalse(FAILED.value)
+        send_data_to_solr(self.solr_connection, [{"foo": "bar"}])
+        self.assertTrue(FAILED.value)
+
+class LiveIndexFailTest(unittest.TestCase):
+    def setUp(self):
+        self.imp = sir.indexing._multiprocessed_import = mock.MagicMock()
+        FAILED.value = False
+        def set_flag_to_false(*args, **kwargs):
+            FAILED.value = True
+        self.imp.side_effect = set_flag_to_false
+
+    def test_error_raised(self):
+        self.assertFalse(FAILED.value)
+        with self.assertRaises(Exception):
+            sir.indexing.live_index(mock.MagicMock())
+        self.assertTrue(FAILED.value)


### PR DESCRIPTION
# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
zas suggested we should have a failsafe in case post requests to Solr fail from sir side.
Currently it requeues the entire pending messages to the search.retry queue in case even a single Post fails.
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [SOLR-XXX](https://tickets.metabrainz.org/browse/SOLR-XXX)


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
