### PR TITLE
Fix barcode compat issues

### DIFF
--- a/sir/schema/__init__.py
+++ b/sir/schema/__init__.py
@@ -370,7 +370,7 @@ SearchRelease = E(modelext.CustomRelease, [
     F("country", "country_dates.country.area.iso_3166_1_codes.code"),
     F("date", "country_dates.date",
       transformfunc=tfs.index_partialdate_to_string),
-    F("barcode", "barcode"),
+    F("barcode", "barcode", transformfunc=tfs.null_value),
     F("catno", "labels.catalog_number"),
     F("comment", "comment"),
     F("format", "mediums.format.name"),

--- a/sir/schema/__init__.py
+++ b/sir/schema/__init__.py
@@ -370,7 +370,7 @@ SearchRelease = E(modelext.CustomRelease, [
     F("country", "country_dates.country.area.iso_3166_1_codes.code"),
     F("date", "country_dates.date",
       transformfunc=tfs.index_partialdate_to_string),
-    F("barcode", "barcode", transformfunc=tfs.null_value),
+    F("barcode", "barcode", transformfunc=tfs.fill_none),
     F("catno", "labels.catalog_number"),
     F("comment", "comment"),
     F("format", "mediums.format.name"),

--- a/sir/schema/transformfuncs.py
+++ b/sir/schema/transformfuncs.py
@@ -33,6 +33,11 @@ URL_LINK_TABLE_TO_ENTITYTYPE = {
 }
 
 
+def null_value(values):
+    if "" in values:
+        return values.union(['none'])
+    return values
+
 def integer_sum(values):
     return int(sum(values))
 

--- a/sir/schema/transformfuncs.py
+++ b/sir/schema/transformfuncs.py
@@ -33,9 +33,13 @@ URL_LINK_TABLE_TO_ENTITYTYPE = {
 }
 
 
-def null_value(values):
+def fill_none(values):
+    # When a field is not applicable - for eg. when a release doesn't have a barcode
+    # as opposed to it being unknown it is known but it is `[none]`. `[none]` is stored
+    # in the DB as an empty string, so doing this allows us to search for releases with
+    # `[none]` type barcode via the syntax `barcode:none`
     if "" in values:
-        return values.union(['none'])
+        return values.add('none')
     return values
 
 def integer_sum(values):

--- a/sir/wscompat/convert.py
+++ b/sir/wscompat/convert.py
@@ -10,13 +10,6 @@ from mbrng import models
 
 fix()
 
-#: Constant for a missing barcode
-BARCODE_NONE = "none"
-
-#: Constant for unknown barcode values
-BARCODE_UNKOWN = "-"
-
-
 #: Time format string
 TIME_FORMAT = "%H:%M:%S"
 
@@ -884,7 +877,7 @@ def convert_cdstub(obj):
     tracklist.count = toc.track_count
     cdstub.set_track_list(tracklist)
 
-    if obj.barcode:
+    if obj.barcode is not None:
         cdstub.set_barcode(obj.barcode)
 
     if obj.comment:
@@ -1044,12 +1037,7 @@ def convert_release(obj):
                              artist_credit=convert_artist_credit(obj.artist_credit))  # noqa
 
     if obj.barcode is not None:
-        if obj.barcode != "":
-            release.set_barcode(obj.barcode)
-        else:
-            release.set_barcode(BARCODE_NONE)
-    else:
-        release.set_barcode(BARCODE_UNKOWN)
+        release.set_barcode(obj.barcode)
 
     if obj.comment:
         release.set_disambiguation(obj.comment)


### PR DESCRIPTION
# Summary
The current search fills in values for barcode when its empty or [none] and doesn't differentiate in search between [none] and an unset value. This patch fixes that and allows searching for `barcode:none` to find [none] type barcodes and `-barcode:*` to find barcodes with no value set.
<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [SOLR-XXX](https://tickets.metabrainz.org/browse/SOLR-XXX)


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
