### PR TITLE
SOLR-97: Fix Release Group type for Annotation

### DIFF
--- a/sir/wscompat/convert.py
+++ b/sir/wscompat/convert.py
@@ -760,7 +760,7 @@ def convert_annotation(obj):
     for a in obj.releases:
         l.append(convert_one_annotation(obj, 'release',      a.release))
     for a in obj.release_groups:
-        l.append(convert_one_annotation(obj, 'releasegroup', a.release_group))
+        l.append(convert_one_annotation(obj, 'release-group', a.release_group))
     for a in obj.series:
         l.append(convert_one_annotation(obj, 'series',       a.series))
     for a in obj.works:


### PR DESCRIPTION
# Fix [SOLR-97](https://tickets.metabrainz.org/browse/SOLR-97)

The following applies to the notation of the release group entity type in annotation search only.

Old search server used to return `release_group` as specified in the file [entities.json](https://github.com/metabrainz/musicbrainz-server/blob/master/entities.json), whereas the new search server returns `releasegroup` thus confusing the MusicBrainz server ([MBS-9790](https://tickets.metabrainz.org/browse/MBS-9790)).

This one-line patch fixes that notation.