### PR TITLE
Expand environment variables in configuration values

### DIFF
--- a/docs/source/setup/install.rst
+++ b/docs/source/setup/install.rst
@@ -36,6 +36,11 @@ The easiest way to run sir at the moment is to use a `virtual environment
     pip install -r requirements.txt
     cp config.ini.example config.ini
 
+Note: Environment variables can be used in `config.ini` with the syntaxes
+`$NAME` and `${NAME}`.  Undefined variables will not be replaced at all.
+Escaping is not supported.
+
+
 You can now use sir via::
 
     python -m sir

--- a/sir/__main__.py
+++ b/sir/__main__.py
@@ -19,7 +19,7 @@ logger = logging.getLogger("sir")
 
 def main():
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(prog="sir")
     parser.add_argument("-d", "--debug", action="store_true")
     parser.add_argument("--sqltimings", action="store_true")
     subparsers = parser.add_subparsers()

--- a/sir/config.py
+++ b/sir/config.py
@@ -3,9 +3,15 @@
 import ConfigParser
 import os.path
 
-#: A :class:`ConfigParser.SafeConfigParser` instance holding the configuration
+#: A :class:`SafeExpandingConfigParser` instance holding the configuration
 #: data.
-CFG = None  # type: ConfigParser.SafeConfigParser
+CFG = None  # type: SafeExpandingConfigParser
+
+
+class SafeExpandingConfigParser(ConfigParser.SafeConfigParser, object):
+    def _interpolate(self, section, option, rawval, vars):
+        return os.path.expandvars(super(SafeExpandingConfigParser,
+            self)._interpolate(section, option, rawval, vars))
 
 
 class ConfigError(Exception):
@@ -15,10 +21,10 @@ class ConfigError(Exception):
 def read_config():
     """
     Read config files from all possible locations and set
-    :const:`sir.config.CFG` to a :class:`ConfigParser.SafeConfigParser`
+    :const:`sir.config.CFG` to a :class:`SafeExpandingConfigParser`
     instance.
     """
-    config = ConfigParser.SafeConfigParser()
+    config = SafeExpandingConfigParser()
     read_files = config.read([os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
         "..", "config.ini"


### PR DESCRIPTION
# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

Configuring `sir` using environment variables required to modify the file `config.ini` on the fly.

Example use case: Setting PG password through environment at Docker Compose level.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Expand environment variables of the form `$NAME` and `${NAME}` in configuration values.

Besides, set program name to `sir` (instead of `__main__.py`) for usage message.