### PR TITLE
SEC-2: Update requests to 2.21.0 (latest)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ psycopg2==2.7.3
 retrying==1.3.3
 pysolr==3.7.0
 sqlalchemy==1.0.2
-requests==2.18.3
+requests==2.21.0
 raven==6.1.0
 ujson==1.35


### PR DESCRIPTION
# Relates to [SEC-2](https://tickets.metabrainz.org/browse/SEC-2)

This fixes CVE-2018-18074 which could make it easier for remote attackers to discover sentry credentials by sniffing the network.