### PR TITLE
SOLR-106: Slugify values for searchable fields gender and medium format

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ mb-rngpy==2.7.1
 psycopg2==2.7.3
 retrying==1.3.3
 pysolr==3.7.0
+python-slugify==3.0.0
 sqlalchemy==1.0.2
 requests==2.18.3
 raven==6.1.0

--- a/sir/wscompat/convert.py
+++ b/sir/wscompat/convert.py
@@ -452,7 +452,7 @@ def convert_medium(obj, disc_list=True):
     m = models.medium()
 
     if obj.format is not None:
-        m.set_format(convert_format(obj.format))
+        m.set_format(convert_medium_format(obj.format))
 
     if disc_list:
         dl = models.disc_list(count=len(obj.cdtocs))
@@ -1229,5 +1229,5 @@ def convert_gender(obj):
     return models.gender(valueOf_=obj.name.lower())
 
 
-def convert_format(obj):
+def convert_medium_format(obj):
     return models.format(valueOf_=slugify(obj.name))

--- a/sir/wscompat/convert.py
+++ b/sir/wscompat/convert.py
@@ -827,7 +827,7 @@ def convert_artist(obj):
         artist.set_disambiguation(obj.comment)
 
     if obj.gender is not None:
-        artist.set_gender(convert_gender(obj.gender))
+        artist.set_gender(convert_artist_gender(obj.gender))
 
     if obj.type is not None:
         artist.set_type(obj.type.name)
@@ -1225,7 +1225,7 @@ def convert_release_status(obj):
     return models.status(valueOf_=obj.name)
 
 
-def convert_gender(obj):
+def convert_artist_gender(obj):
     return models.gender(valueOf_=slugify(obj.name))
 
 

--- a/sir/wscompat/convert.py
+++ b/sir/wscompat/convert.py
@@ -1226,7 +1226,7 @@ def convert_release_status(obj):
 
 
 def convert_gender(obj):
-    return models.gender(valueOf_=obj.name.lower())
+    return models.gender(valueOf_=slugify(obj.name))
 
 
 def convert_medium_format(obj):

--- a/sir/wscompat/convert.py
+++ b/sir/wscompat/convert.py
@@ -1,6 +1,7 @@
 # Copyright (c) Wieland Hoffmann
 # License: MIT, see LICENSE for details
 from sir.wscompat.modelfix import fix
+from slugify import slugify
 try:
     # Python 3
     from functools import lru_cache
@@ -1229,4 +1230,4 @@ def convert_gender(obj):
 
 
 def convert_format(obj):
-    return models.format(valueOf_=obj.name)
+    return models.format(valueOf_=slugify(obj.name))

--- a/test/test_wscompat_convert.py
+++ b/test/test_wscompat_convert.py
@@ -8,14 +8,14 @@ from mbdata.types import PartialDate
 from mock import MagicMock
 from sir.wscompat.convert import (
     calculate_type,
-    convert_format,
+    convert_medium_format,
     partialdate_to_string,
 )
 
 
 class MediumFormatConverterTest(unittest.TestCase):
     def do(self, input, expected):
-        output = convert_format(MediumFormat(name=input)).get_valueOf_()
+        output = convert_medium_format(MediumFormat(name=input)).get_valueOf_()
         self.assertEqual(output, expected)
 
     def test_medium_formats(self):

--- a/test/test_wscompat_convert.py
+++ b/test/test_wscompat_convert.py
@@ -1,8 +1,31 @@
+#!/usr/bin/env python
+# coding: utf-8
+# Copyright (c) 2014, 2017 Wieland Hoffmann, MetaBrainz Foundation
 import unittest
 
+from mbdata.models import MediumFormat
 from mbdata.types import PartialDate
 from mock import MagicMock
-from sir.wscompat.convert import partialdate_to_string, calculate_type
+from sir.wscompat.convert import (
+    calculate_type,
+    convert_format,
+    partialdate_to_string,
+)
+
+
+class MediumFormatConverterTest(unittest.TestCase):
+    def do(self, input, expected):
+        output = convert_format(MediumFormat(name=input)).get_valueOf_()
+        self.assertEqual(output, expected)
+
+    def test_medium_formats(self):
+        ds = [('3.5" Floppy Disk', '3-5-floppy-disk'),
+              ('8cm CD+G', '8cm-cd-g'),
+              ('DVDplus (CD side)', 'dvdplus-cd-side'),
+              ('Pathé disc', 'pathe-disc')]
+
+        for d, expected in ds:
+            self.do(d, expected)
 
 
 class PartialDateConverterTest(unittest.TestCase):


### PR DESCRIPTION
# Fixes [SOLR-106](https://tickets.metabrainz.org/browse/SOLR-106): Cannot search release by medium format with special characters

## Problem

Could not search for release on _3.5" Floppy Disk_ or _Pathé disc_.
Similarly, could not search for artist of _not applicable_ gender.

## Solution

Slugify values for gender (was lowercased) and medium format.

Note that symbol `+` is replaced with `-` but it doesn’t cause any overlap with existing values.