### PR TITLE
Update SIR to MMD schema 2.0 v-2019-01-07

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ backports.functools_lru_cache==1.0.1
 enum34==1.1.6
 enumerate_skip==1.0
 mbdata==2017.6.2
-mb-rngpy==2.7.1
+mb-rngpy==2.20190107.0
 psycopg2==2.7.3
 retrying==1.3.3
 pysolr==3.7.0

--- a/searchfields.org
+++ b/searchfields.org
@@ -50,6 +50,7 @@ The artist index contains the following fields you can search:
 *** DONE ended
 *** DONE gender
 *** DONE ipi
+*** DONE isni
 *** DONE sortname
 *** DONE tag
 *** DONE type
@@ -70,7 +71,7 @@ search:
 
 ** Label [14/14]
 
-The label ndex contains the following fields you can search:
+The label index contains the following fields you can search:
 
 *** DONE alias
 *** DONE area
@@ -81,6 +82,7 @@ The label ndex contains the following fields you can search:
 *** DONE end
 *** DONE ended
 *** DONE ipi
+*** DONE isni
 *** DONE label
 *** DONE labelaccent
 *** DONE laid

--- a/sir/wscompat/convert.py
+++ b/sir/wscompat/convert.py
@@ -350,7 +350,8 @@ def convert_recording_work_relation_list(obj):
 
 def convert_ipi_list(obj):
     """
-    :type obj: :class:`[mbdata.models.ArtistIPI]`
+    :type obj: :class:`[mbdata.models.ArtistIPI]` or
+               :class:`[mbdata.models.LabelIPI]`
     """
     ipi_list = models.ipi_list()
     [ipi_list.add_ipi(i.ipi) for i in obj]

--- a/sir/wscompat/convert.py
+++ b/sir/wscompat/convert.py
@@ -1045,7 +1045,7 @@ def convert_release(obj):
         release.set_disambiguation(obj.comment)
 
     if obj.packaging is not None:
-        release.set_packaging(obj.packaging.name)
+        release.set_packaging(convert_release_packaging(obj.packaging))
 
     if len(obj.country_dates) > 0:
         release.set_release_event_list(
@@ -1216,6 +1216,13 @@ def convert_release_group_primary_type(obj):
     :type obj: :class:`mbdata.models.ReleaseGroupPrimaryType`
     """
     return models.primary_type(valueOf_=obj.name, id=obj.gid)
+
+
+def convert_release_packaging(obj):
+    """
+    :type obj: :class:`mbdata.models.ReleasePackaging`
+    """
+    return models.packaging(valueOf_=obj.name, id=obj.gid)
 
 
 def convert_release_status(obj):

--- a/sir/wscompat/convert.py
+++ b/sir/wscompat/convert.py
@@ -357,6 +357,16 @@ def convert_ipi_list(obj):
     return ipi_list
 
 
+def convert_isni_list(obj):
+    """
+    :type obj: :class:`[mbdata.models.ArtistISNI]` or
+               :class:`[mbdata.models.LabelISNI]`
+    """
+    isni_list = models.isni_list()
+    [isni_list.add_isni(i.isni) for i in obj]
+    return isni_list
+
+
 def convert_isrc(obj):
     """
     :type obj: :class:`mbdata.models.ISRC`
@@ -853,6 +863,9 @@ def convert_artist(obj):
     if len(obj.ipis) > 0:
         artist.set_ipi_list(convert_ipi_list(obj.ipis))
 
+    if len(obj.isnis) > 0:
+        artist.set_isni_list(convert_isni_list(obj.isnis))
+
     if len(obj.tags) > 0:
         artist.set_tag_list(convert_tag_list(obj.tags))
 
@@ -986,6 +999,9 @@ def convert_label(obj):
 
     if len(obj.ipis) > 0:
         label.set_ipi_list(convert_ipi_list(obj.ipis))
+
+    if len(obj.isnis) > 0:
+        label.set_isni_list(convert_isni_list(obj.isnis))
 
     if obj.comment:
         label.set_disambiguation(obj.comment)

--- a/sir/wscompat/convert.py
+++ b/sir/wscompat/convert.py
@@ -882,7 +882,7 @@ def convert_cdstub(obj):
         cdstub.set_barcode(obj.barcode)
 
     if obj.comment:
-        cdstub.set_comment(obj.comment)
+        cdstub.set_disambiguation(obj.comment)
 
     return cdstub
 

--- a/test/test_wscompat_convert.py
+++ b/test/test_wscompat_convert.py
@@ -4,12 +4,15 @@ import xml.etree.ElementTree as ElementTree
 from mbdata.models import (
     Artist,
     ArtistCreditName,
+    ArtistISNI,
+    LabelISNI,
     ReleaseGroupSecondaryType,
     ReleaseGroupSecondaryTypeJoin,
     ReleasePackaging,
 )
 from mbdata.types import PartialDate
 from sir.wscompat.convert import (
+    convert_isni_list,
     convert_name_credit,
     convert_release_packaging,
     partialdate_to_string,
@@ -25,6 +28,57 @@ def xml_elements_equal(e1, e2):
             len(e1) != len(e2)):
         return False
     return all(xml_elements_equal(c1, c2) for c1, c2 in zip(e1, e2))
+
+
+class IsniListConverterTest(unittest.TestCase):
+    """Test that ISNI lists are converted correctly."""
+
+    def check_isni_list(self, actual, expected):
+        output = convert_isni_list(actual).to_etree()
+        expected_xml = ElementTree.fromstring(expected)
+        self.assertTrue(xml_elements_equal(output, expected_xml))
+
+    def _create_isni_list(self, isni_class, only_isni_list):
+        isni_list = []
+        for only_isni in only_isni_list:
+            isni = isni_class()
+            isni.isni = only_isni
+            isni_list.append(isni)
+        return isni_list
+
+    def test_artist_isni_list(self):
+        artist_isni_list = self._create_isni_list(
+            isni_class=ArtistISNI,
+            only_isni_list=[u'000000005705334X',
+                            u'0000000078243206',
+                            u'0000000041815776'],
+        )
+        expected_artist_isni_list = '''
+        <isni-list xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+            <isni>000000005705334X</isni>
+            <isni>0000000078243206</isni>
+            <isni>0000000041815776</isni>
+        </isni-list>
+        '''
+        self.check_isni_list(
+            actual=artist_isni_list,
+            expected=expected_artist_isni_list,
+        )
+
+    def test_label_isni_list(self):
+        label_isni_list = self._create_isni_list(
+            isni_class=LabelISNI,
+            only_isni_list=[u'000000011781560X'],
+        )
+        expected_label_isni_list = '''
+        <isni-list xmlns="http://musicbrainz.org/ns/mmd-2.0#">
+            <isni>000000011781560X</isni>
+        </isni-list>
+        '''
+        self.check_isni_list(
+            actual=label_isni_list,
+            expected=expected_label_isni_list,
+        )
 
 
 class NameCreditConverterTest(unittest.TestCase):

--- a/test/test_wscompat_convert.py
+++ b/test/test_wscompat_convert.py
@@ -1,10 +1,17 @@
 import unittest
 import xml.etree.ElementTree as ElementTree
 
-from mbdata.models import Artist, ArtistCreditName, ReleaseGroupSecondaryType, ReleaseGroupSecondaryTypeJoin
+from mbdata.models import (
+    Artist,
+    ArtistCreditName,
+    ReleaseGroupSecondaryType,
+    ReleaseGroupSecondaryTypeJoin,
+    ReleasePackaging,
+)
 from mbdata.types import PartialDate
 from sir.wscompat.convert import (
     convert_name_credit,
+    convert_release_packaging,
     partialdate_to_string,
     calculate_type,
 )
@@ -154,3 +161,33 @@ class OldTypeCalculatorTest(unittest.TestCase):
                                                         excepted_outputs):
             secondary_types = self._create_secondary_types(secondary_type_list)
             self.check_legacy_type(primary_type, secondary_types, excepted_output)
+
+
+class ReleasePackagingConverterTest(unittest.TestCase):
+    """Test that release packagings are converted correctly."""
+
+    def check_release_packaging(self, actual, expected):
+        output = convert_release_packaging(actual).to_etree()
+        expected_xml = ElementTree.fromstring(expected)
+        self.assertTrue(xml_elements_equal(output, expected_xml))
+
+    def _create_release_packaging(self, gid, name):
+        release_packaging = ReleasePackaging
+        release_packaging.gid = gid
+        release_packaging.name = name
+        return release_packaging
+
+    def test_release_packaging(self):
+        release_packaging = self._create_release_packaging(
+            gid='ec27701a-4a22-37f4-bfac-6616e0f9750a',
+            name='Jewel Case',
+        )
+        expected_release_packaging = '''
+        <packaging xmlns="http://musicbrainz.org/ns/mmd-2.0#"
+                   id="ec27701a-4a22-37f4-bfac-6616e0f9750a"
+        >Jewel Case</packaging>
+        '''
+        self.check_release_packaging(
+            actual=release_packaging,
+            expected=expected_release_packaging,
+        )


### PR DESCRIPTION
# Summary

Update to [MMD schema 2.0 used in production as of January 7th, 2019](https://github.com/metabrainz/mmd-schema/releases/tag/v-2019-01-07).

# Problem

Changes in MMD schema and/or MB WS have not been followed by MB SOLR which no longer complies with MMD 2.0 schema.

# Solution

Update the Python bindings for MMD schema to [mb-rngpy v-2.20190107.0](https://github.com/metabrainz/mb-rngpy/releases/tag/v-2.20190107.0).

Make relevant changes to follow https://github.com/metabrainz/mb-rngpy/pull/3 which includes:

* [MBS-8974](https://tickets.metabrainz.org/browse/MBS-8974): Add isni-list to artist & label.
  :arrow_right: addressed with commit https://github.com/metabrainz/sir/commit/50db024a8a8b7e55eae9e7c592adf8535cf02bdf;
* [MBS-8978](https://tickets.metabrainz.org/browse/MBS-8978): Add packaging id attribute of type UUID
  :arrow_right: addressed with commit https://github.com/metabrainz/sir/commit/1bf1c774266657c3c6342e101f81064c6166122e;
* [MBS-8979](https://tickets.metabrainz.org/browse/MBS-8979): Add cdstub as a possibility under metadata
  :ok: not relevant to the search server which returns CD stubs list that matches [`mmd-schema`](https://github.com/metabrainz/mmd-schema/blob/v-2019-01-07/schema/musicbrainz_mmd-2.0.rng#L150-L152);
* [MBS-8980](https://tickets.metabrainz.org/browse/MBS-8980): CDStubs have "disambiguation" not "comment"
  :arrow_right: addressed with commit https://github.com/metabrainz/sir/commit/b81672a1137e4922f238864c3507a1479e9de5f4;
* [MBS-9470](https://tickets.metabrainz.org/browse/MBS-9470): Add relationship attribute type id
  :ok:  already handled by sir with https://github.com/metabrainz/sir/blob/d3e12fa2811e05ade63905510d57527c819d2748/sir/wscompat/convert.py#L281.

Plus complete https://github.com/metabrainz/sir/pull/95 by adding ISNIs to `searchfields.org` and update IPI doc.

# Action

I will update https://github.com/metabrainz/mb-solr/pull/31 after.
