### PR TITLE
Update requirements mbdata and pysolr

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ mbdata==25.0.0
 mb-rngpy==2.20190107.0
 psycopg2==2.7.3
 retrying==1.3.3
-pysolr==3.7.0
+pysolr==3.8.1
 sqlalchemy==1.0.2
 requests==2.21.0
 raven==6.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ amqp==1.4.9
 backports.functools_lru_cache==1.0.1
 enum34==1.1.6
 enumerate_skip==1.0
-mbdata==2017.6.2
+mbdata==25.0.0
 mb-rngpy==2.20190107.0
 psycopg2==2.7.3
 retrying==1.3.3

--- a/sir/indexing.py
+++ b/sir/indexing.py
@@ -297,10 +297,7 @@ def send_data_to_solr(solr_connection, data):
     :raises: :class:`solr:solr.SolrException`
     """
     try:
-        # PySolr defaults to committing after every addition. This is slow.
-        # Let Solr autocommit according to its conf. and commit manually once
-        # all documents are sent.
-        solr_connection.add(data, commit=False)
+        solr_connection.add(data)
         logger.debug("Done sending data to Solr")
     except SolrError:
         get_sentry().captureException(extra={"data": data})

--- a/sir/schema/searchentities.py
+++ b/sir/schema/searchentities.py
@@ -258,10 +258,6 @@ class SearchEntity(object):
             if isinstance(tempvals, set) and len(tempvals) == 1:
                 tempvals = tempvals.pop()
             if tempvals is not None and tempvals:
-                # TO-DO (samj1912): Remove this typecast once https://github.com/django-haystack/pysolr/pull/229
-                # is merged.
-                if isinstance(tempvals, set):
-                    tempvals = list(tempvals)
                 data[fieldname] = tempvals
 
         if (config.CFG.getboolean("sir", "wscompat") and self.compatconverter is

--- a/test/test_indexing.py
+++ b/test/test_indexing.py
@@ -16,13 +16,13 @@ class QueueToSolrTest(unittest.TestCase):
 
     def test_normal_send(self):
         queue_to_solr(self.queue, 1, self.solr_connection)
-        expected = [mock.call([{"foo": "bar"}], commit=False), mock.call([], commit=False), ]
+        expected = [mock.call([{"foo": "bar"}]), mock.call([]), ]
         calls = self.solr_connection.add.call_args_list
         self.assertEqual(calls, expected)
 
     def test_queue_drained_send(self):
         queue_to_solr(self.queue, 2, self.solr_connection)
-        self.solr_connection.add.assert_called_once_with([{"foo": "bar"}], commit=False)
+        self.solr_connection.add.assert_called_once_with([{"foo": "bar"}])
 
 
 class SendDataToSolrTest(unittest.TestCase):
@@ -32,7 +32,7 @@ class SendDataToSolrTest(unittest.TestCase):
 
     def test_normal_send(self):
         send_data_to_solr(self.solr_connection, [{"foo": "bar"}])
-        expected = [mock.call([{"foo": "bar"}], commit=False)]
+        expected = [mock.call([{"foo": "bar"}])]
         calls = self.solr_connection.add.call_args_list
         self.assertEqual(calls, expected)
 

--- a/test/test_searchentities.py
+++ b/test/test_searchentities.py
@@ -26,7 +26,7 @@ class QueryResultToDictTest(unittest.TestCase):
         self.expected = {
             "id": 1,
             "c_bar": "foo",
-            "c_bar_trans": ["foo", "yay"],
+            "c_bar_trans": {"foo", "yay"},
         }
         c = models.C(id=2, bar="foo")
         self.val = models.B(id=1, c=c)


### PR DESCRIPTION
No breaking changes:
* mbdata: follows non-disruptive schema change 25;
* pysolr: no longer commit by default, see [release tag v3.8.1](https://github.com/django-haystack/pysolr/releases/tag/v3.8.1);

Removed disabling auto-commit from `sir/indexing.py` since it is now disabled by default.

(Edit: no longer bump sqlalchemy to 1.3.3 as it [breaks tests](https://ci.metabrainz.org/job/sir/476/#showFailuresLink), should check [migration from 1.0](https://docs.sqlalchemy.org/en/11/changelog/migration_11.html), [from 1.1](https://docs.sqlalchemy.org/en/12/changelog/migration_12.html), and [from 1.2](https://docs.sqlalchemy.org/en/13/changelog/migration_13.html) again.)