### PR TITLE
Add labels and tag to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,20 @@
-FROM metabrainz/python:2.7
+ARG PYTHON_VERSION=2.7
+FROM metabrainz/python:$PYTHON_VERSION
+
+ARG SIR_VERSION
+
+ARG PYTHON_VERSION
+
+ARG BUILD_DATE
+ARG VCS_REF
+
+LABEL org.label-schema.build-date=${BUILD_DATE} \
+      org.label-schema.schema-version="1.0.0-rc1" \
+      org.label-schema.vcs-url="https://github.com/metabrainz/sir.git" \
+      org.label-schema.vcs-ref=${VCS_REF} \
+      org.label-schema.vendor="MetaBrainz Foundation" \
+      org.metabrainz.based-on-image="metabrainz/python:${PYTHON_VERSION}" \
+      org.metabrainz.sir.version=${SIR_VERSION}
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -1,6 +1,23 @@
 #!/bin/bash
+#
+# Build image from the currently checked out version of SIR
+# and push it to the Docker Hub, tagged with version.
+#
+# Usage:
+#   $ ./push.sh
+
+set -e -u
+
+vcs_ref=`git describe --always --broken --dirty`
+version=${vcs_ref#v}
+deployment=git2consul
+tag=${version}-${deployment}
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../"
 
-docker build -t metabrainz/sir .
-docker push metabrainz/sir
+docker build \
+  --build-arg SIR_VERSION=${version} \
+  --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+  --build-arg VCS_REF=${vcs_ref} \
+  --tag metabrainz/sir:${tag} .
+docker push metabrainz/sir:${tag}


### PR DESCRIPTION
Tag docker image with:
* git ref (most recent tag, or current commit, with dirty mark)
* deployment target (currently 'git2consul' in production)

Label docker image with:
* sir version derived from git ref
* metabrainz/python base image version
* build timestamp

# Summary

It improves building and releasing metabrainz/sir docker image to docker hub.

# Action

Update docker-server-configs accordingly.
