### PR TITLE
SOLR-113: Skip indexing entity on unwanted control character

### DIFF
--- a/sir/indexing.py
+++ b/sir/indexing.py
@@ -113,6 +113,7 @@ def _multiprocessed_import(entity_names, live=False, entities=None):
     # memory
     pool = multiprocessing.Pool(max_processes, maxtasksperchild=1)
     for e in entity_names:
+        logger.info("Importing %s...", e)
         index_function_args = []
         # `entities` will be None when reindexing the entire DB
         entity_id_list = list(entities.get(e, set())) if entities else None
@@ -162,7 +163,7 @@ def _multiprocessed_import(entity_names, live=False, entities=None):
             logger.exception(exc)
             pool.terminate()
         else:
-            logger.debug("Importing %s successful!", e)
+            logger.info("Successfully imported %s!", e)
         entity_data_queue.put(STOP)
         for p in solr_processes:
             p.join()
@@ -207,7 +208,7 @@ def index_entity(entity_name, bounds, data_queue):
     :param Queue.Queue data_queue:
     """
     model = SCHEMA[entity_name].model
-    logger.debug("Indexing %s %s", model, bounds)
+    logger.debug("Importing %s %s", model, bounds)
     lower_bound, upper_bound = bounds
     if upper_bound is not None:
         condition = and_(model.id >= lower_bound, model.id < upper_bound)
@@ -229,7 +230,7 @@ def live_index_entity(entity_name, ids, data_queue):
     if not PROCESS_FLAG.value:
         return
     condition = and_(SCHEMA[entity_name].model.id.in_(ids))
-    logger.debug("Indexing %s new rows for entity %s", len(ids), entity_name)
+    logger.debug("Importing %s new rows for entity %s", len(ids), entity_name)
     _query_database(entity_name, condition, data_queue)
 
 

--- a/sir/indexing.py
+++ b/sir/indexing.py
@@ -156,11 +156,11 @@ def _multiprocessed_import(entity_names, live=False, entities=None):
                 p.terminate()
                 p.join()
             pool.terminate()
-            pool.join()
             raise
         except Exception as exc:
             logger.error("Failed to import %s.", e)
             logger.exception(exc)
+            pool.terminate()
         else:
             logger.debug("Importing %s successful!", e)
         entity_data_queue.put(STOP)

--- a/sir/indexing.py
+++ b/sir/indexing.py
@@ -186,7 +186,8 @@ def _index_entity_process_wrapper(args, live=False):
         if live:
             return live_index_entity(*args)
         return index_entity(*args)
-    except Exception:
+    except Exception as exc:
+        logger.exception(exc)
         raise
 
 

--- a/sir/indexing.py
+++ b/sir/indexing.py
@@ -159,6 +159,7 @@ def _multiprocessed_import(entity_names, live=False, entities=None):
             pool.join()
             raise
         except Exception as exc:
+            logger.error("Failed to import %s.", e)
             logger.exception(exc)
         else:
             logger.debug("Importing %s successful!", e)
@@ -187,6 +188,9 @@ def _index_entity_process_wrapper(args, live=False):
             return live_index_entity(*args)
         return index_entity(*args)
     except Exception as exc:
+        logger.error("Failed to import %s with id in bounds %s",
+                     args[0],
+                     args[1])
         logger.exception(exc)
         raise
 


### PR DESCRIPTION
# Summary

Skip indexing entity on unwanted control character, rather than abort indexing the whole core.

# Problem

XML incompatible strings abort reindexing annotation, recording, release, and url cores.

* JIRA ticket: [SOLR-113](https://tickets.metabrainz.org/browse/SOLR-113)

# Solution

* Handling ValueError raised from row converter, so as to skip (and log) affected row only.
* Logging other exceptions at pool worker level, so as to provide more helpful details.

# Action

Search Indexes:
* Reindex release core then annotation, recording, and url cores.

MusicBrainz Server:
* Prevent invalid characters to be entered, see [MBS-9112](https://tickets.metabrainz.org/browse/MBS-9112).

MusicBrainz Database:
* Clean already entered data (this patch logs table name and id of each skipped row)