### PR TITLE
Modernize Python 2 code and update dependencies

### DIFF
--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -25,5 +25,6 @@ RUN pip install -r requirements_dev.txt
 COPY . /code/
 
 CMD py.test --junitxml=/data/test_report.xml \
+            --cov=sir \
             --cov-report xml:/data/coverage.xml \
             --cov-report html:/data/coverage-html

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ psycopg2==2.8.4
 retrying==1.3.3
 pysolr==3.8.1
 sqlalchemy==1.0.19
-requests==2.21.0
+requests==2.22.0
 raven==6.1.0
 ujson==1.35

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ enum34==1.1.6
 enumerate_skip==1.0
 mbdata==25.0.0
 mb-rngpy==2.20190107.0
-psycopg2==2.7.3.2
+psycopg2==2.8.4
 retrying==1.3.3
 pysolr==3.8.1
 sqlalchemy==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ mb-rngpy==2.20190107.0
 psycopg2==2.8.4
 retrying==1.3.3
 pysolr==3.8.1
-sqlalchemy==1.0.2
+sqlalchemy==1.0.19
 requests==2.21.0
 raven==6.1.0
 ujson==1.35

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-amqp==1.4.9
+amqp==2.5.2
 backports.functools_lru_cache==1.0.1
 enum34==1.1.6
 enumerate_skip==1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 amqp==2.5.2
 backports.functools_lru_cache==1.0.1
 enum34==1.1.6
-enumerate_skip==1.0
 mbdata==25.0.0
 mb-rngpy==2.20190107.0
 psycopg2==2.8.4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-pytest==3.2.0
-pytest-cov==2.5.1
-mock==2.0.0
+pytest==4.6.9
+pytest-cov==2.8.1
+mock==3.0.5
 pysqlite==2.8.3

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def update_version_py():
 def get_version():
     try:
         f = open("sir/version.py")
-    except IOError, e:
+    except IOError as e:
         import errno
         if e.errno == errno.ENOENT:
             update_version_py()

--- a/sir/__main__.py
+++ b/sir/__main__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Copyright (c) 2014, 2015, 2019 Wieland Hoffmann, MetaBrainz Foundation
 # License: MIT, see LICENSE for details
 import argparse
@@ -5,7 +6,7 @@ import logging
 import multiprocessing
 import ConfigParser
 
-import config
+from . import config
 from . import init_raven_client
 from .amqp.extension_generation import generate_extension
 from .amqp.handler import watch

--- a/sir/amqp/message.py
+++ b/sir/amqp/message.py
@@ -56,7 +56,7 @@ class Message(object):
 
         try:
             data = ujson.loads(amqp_message.body)
-        except StandardError as e:
+        except Exception as e:
             raise InvalidMessageContentException("Invalid message format (expected JSON): %s" % e)
         table_name = data.pop(MSG_JSON_TABLE_NAME_KEY, None)
 

--- a/sir/amqp/message.py
+++ b/sir/amqp/message.py
@@ -56,7 +56,7 @@ class Message(object):
 
         try:
             data = ujson.loads(amqp_message.body)
-        except Exception as e:
+        except ValueError as e:
             raise InvalidMessageContentException("Invalid message format (expected JSON): %s" % e)
         table_name = data.pop(MSG_JSON_TABLE_NAME_KEY, None)
 

--- a/sir/schema/transformfuncs.py
+++ b/sir/schema/transformfuncs.py
@@ -67,7 +67,7 @@ def index_partialdate_to_string(dates):
 
 def qdur(durations):
     if len(durations):
-        return durations.pop() / 2000
+        return durations.pop() // 2000
     return None
 
 

--- a/sir/util.py
+++ b/sir/util.py
@@ -131,9 +131,11 @@ def create_amqp_connection():
     :rtype: :class:`amqp:amqp.connection.Connection`
     """
     cget = partial(config.CFG.get, "rabbitmq")
-    return amqp.Connection(
+    conn = amqp.Connection(
         host=cget("host"),
         userid=cget("user"),
         password=cget("password"),
         virtual_host=cget("vhost"),
     )
+    conn.connect()
+    return conn

--- a/test/test_amqp_handler.py
+++ b/test/test_amqp_handler.py
@@ -5,7 +5,7 @@
 import mock
 import unittest
 
-from amqp import Message as Amqp_Message
+from amqp.basic_message import Message as Amqp_Message
 from logging import basicConfig, CRITICAL
 from sir.amqp import handler
 from sir.amqp.message import Message
@@ -28,6 +28,7 @@ class AmqpTestCase(unittest.TestCase):
             body='{"_table": "%s", "id": "%s"}' % (self.entity_type, self.id_string),
             channel=mock.Mock(),
             application_headers={},
+            delivery_tag=object(),
         )
 
         self.message.delivery_info = {"routing_key": self.routing_key}
@@ -36,8 +37,7 @@ class AmqpTestCase(unittest.TestCase):
         handler.solr_connection = mock.Mock()
         handler.solr_version_check = mock.Mock()
         handler.live_index = mock.MagicMock()
-        self.delivery_tag = object()
-        self.message.delivery_tag = self.delivery_tag
+        self.delivery_tag = self.message.delivery_tag
 
         db_session_patcher = mock.patch("sir.amqp.handler.db_session")
         self.addCleanup(db_session_patcher.stop)
@@ -120,8 +120,9 @@ class HandlerTest(AmqpTestCase):
         self.message = Amqp_Message(
             body='{"_table": "%s", "gid": "%s"}' % (self.entity_type, entity_gid),
             application_headers={},
+            delivery_tag=object(),
         )
-        self.message.delivery_tag = self.delivery_tag
+        self.delivery_tag = self.message.delivery_tag
         self.message.delivery_info = {"routing_key": self.routing_key}
         self.handler.delete_callback(self.message, "search.delete")
 

--- a/test/test_amqp_message.py
+++ b/test/test_amqp_message.py
@@ -1,6 +1,6 @@
 import unittest
 
-from amqp import Message
+from amqp.basic_message import Message
 from sir.amqp.message import (InvalidMessageContentException,
                               Message as PMessage,
                               MESSAGE_TYPES)


### PR DESCRIPTION
# Summary

* This is a refactoring

* Modernize Python 2 code (`futurize --stage1`) and upgrade dependencies as much as possible.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* To prepare for Python 3 (SEARCH-594), Python 2 code must be modernized ([in-depth guide](http://python3porting.com/preparing.html)) and dependencies must be updated to avoid known incompatibilities with recent versions of Python 3. 

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Upgrading most dependencies didn’t require any change to the code but:
* amqp: Since 2.0.0 `Connection.connect()` must be called, see [changelog](https://amqp.readthedocs.io/en/2.5.2/changelog.html).
* sqlalchemy: Upgrading to version 1.1/1.2/1.3 is not straightforward and will require a separate PR.