### PR TITLE
SEARCH-623 (indexer): Add id to artist gender

### DIFF
--- a/sir/schema/__init__.py
+++ b/sir/schema/__init__.py
@@ -133,6 +133,7 @@ SearchArtist = E(modelext.CustomArtist, [
                 "aliases.locale", "aliases.primary_for_locale",
                 "aliases.begin_date", "aliases.end_date",
                 "begin_area.gid", "area.gid", "end_area.gid",
+                "gender.gid",
                 "type.gid"]
 )
 

--- a/sir/wscompat/convert.py
+++ b/sir/wscompat/convert.py
@@ -1253,7 +1253,7 @@ def convert_gender(obj):
     """
     :type obj: :class:`mbdata.models.Gender`
     """
-    return models.gender(valueOf_=obj.name.lower())
+    return models.gender(valueOf_=obj.name.lower(), id=obj.gid)
 
 
 def convert_format(obj):

--- a/sir/wscompat/convert.py
+++ b/sir/wscompat/convert.py
@@ -1250,6 +1250,9 @@ def convert_release_status(obj):
 
 
 def convert_gender(obj):
+    """
+    :type obj: :class:`mbdata.models.Gender`
+    """
     return models.gender(valueOf_=obj.name.lower())
 
 

--- a/test/test_wscompat_convert.py
+++ b/test/test_wscompat_convert.py
@@ -5,6 +5,7 @@ from mbdata.models import (
     Artist,
     ArtistCreditName,
     ArtistISNI,
+    Gender,
     LabelISNI,
     ReleaseGroupSecondaryType,
     ReleaseGroupSecondaryTypeJoin,
@@ -12,6 +13,7 @@ from mbdata.models import (
 )
 from mbdata.types import PartialDate
 from sir.wscompat.convert import (
+    convert_gender,
     convert_isni_list,
     convert_name_credit,
     convert_release_packaging,
@@ -28,6 +30,36 @@ def xml_elements_equal(e1, e2):
             len(e1) != len(e2)):
         return False
     return all(xml_elements_equal(c1, c2) for c1, c2 in zip(e1, e2))
+
+
+class GenderConverterTest(unittest.TestCase):
+    """Test that gender is converted correctly."""
+
+    def check_gender(self, actual, expected):
+        output = convert_gender(actual).to_etree()
+        expected_xml = ElementTree.fromstring(expected)
+        self.assertTrue(xml_elements_equal(output, expected_xml))
+
+    def _create_gender(self, gid, name):
+        gender = Gender
+        gender.gid = gid
+        gender.name = name
+        return gender
+
+    def test_gender(self):
+        gender = self._create_gender(
+            gid='8cf3c8c8-4af9-4b53-bad4-e43c0450ba04',
+            name='Not applicable',
+        )
+        expected_gender = '''
+        <gender xmlns="http://musicbrainz.org/ns/mmd-2.0#"
+                   id="8cf3c8c8-4af9-4b53-bad4-e43c0450ba04"
+        >not applicable</gender>
+        '''
+        self.check_gender(
+            actual=gender,
+            expected=expected_gender,
+        )
 
 
 class IsniListConverterTest(unittest.TestCase):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to Search Index Rebuilder (SIR).
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/sir/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

SEARCH-623: 'gender-id' is missing from JSON/XML artist search results


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

* Use gender `gid` along with its name when converting gender object.
* Add `gender.id` as not-searchable field in `extrapaths` for `SearchArtist`.


# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->
* [X] Add test for conversion
* [X] Check the documentation for potential updates:
    Artist examples given in [MusicBrainz API / Search](https://musicbrainz.org/doc/MusicBrainz_API/Search) have no gender set.

# Action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

1. Merge metabrainz/mb-solr#40 too.
2. Release both PRs at the same time.
