### PR TITLE
SEARCH-218 (indexer): Recording’s first release date

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 amqp==2.5.2
 backports.functools_lru_cache==1.0.1
 enum34==1.1.6
-mbdata==25.0.0
-mb-rngpy==2.20190107.0
+git+https://github.com/yvanzo/mbdata.git@v26.0.dev3#egg=mbdata
+git+https://github.com/metabrainz/mb-rngpy.git@v-2.20201112.0#egg=mb-rngpy
 psycopg2==2.8.4
 retrying==1.3.3
 pysolr==3.8.1

--- a/searchfields.org
+++ b/searchfields.org
@@ -111,7 +111,7 @@ The place index contains the following fields you can search:
 
 Place search terms with no fields specified search the place, alias,
 address and area fields.
-** Recording [30/30]
+** Recording [31/31]
 
 Recording searches can contain you can search:
 
@@ -124,6 +124,7 @@ Recording searches can contain you can search:
 *** DONE date
 *** DONE dur
 *** DONE format
+*** DONE firstreleasedate
 *** DONE isrc
 *** DONE number
 *** DONE position

--- a/sir/schema/__init__.py
+++ b/sir/schema/__init__.py
@@ -295,6 +295,8 @@ SearchRecording = E(modelext.CustomRecording, [
     F("date", "tracks.medium.release.country_dates.date",
       transformfunc=tfs.index_partialdate_to_string),
     F("dur", "length"),
+    F("firstreleasedate", "first_release.date",
+      transformfunc=tfs.index_partialdate_to_string),
     F("format", "tracks.medium.format.name"),
     F("isrc", "isrcs.isrc"),
     F("mbid", "gid"),

--- a/sir/wscompat/convert.py
+++ b/sir/wscompat/convert.py
@@ -1026,6 +1026,9 @@ def convert_recording(obj):
     if obj.comment:
         recording.set_disambiguation(obj.comment)
 
+    if obj.first_release is not None and obj.first_release.date is not None:
+        recording.set_first_release_date(partialdate_to_string(obj.first_release.date))
+
     recording.set_length(obj.length)
 
     if len(obj.isrcs) > 0:

--- a/sql/CreateFunctions.sql
+++ b/sql/CreateFunctions.sql
@@ -2234,6 +2234,42 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION search_recording_first_release_date_insert() RETURNS trigger
+    AS $$
+BEGIN
+    PERFORM amqp.publish(2, 'search', 'index', (
+            WITH keys(recording) AS (SELECT NEW.recording)
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"recording_first_release_date"'),
+                             '{_operation}', '"insert"')::text FROM keys
+        ));
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION search_recording_first_release_date_update() RETURNS trigger
+    AS $$
+BEGIN
+    PERFORM amqp.publish(2, 'search', 'update', (
+            WITH keys(recording) AS (SELECT NEW.recording)
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"recording_first_release_date"'),
+                             '{_operation}', '"update"')::text FROM keys
+        ));
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION search_recording_first_release_date_delete() RETURNS trigger
+    AS $$
+BEGIN
+    PERFORM amqp.publish(2, 'search', 'update', (
+            WITH keys(recording) AS (SELECT OLD.recording)
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"recording_first_release_date"'),
+                             '{_operation}', '"delete"')::text FROM keys
+        ));
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION search_medium_format_insert() RETURNS trigger
     AS $$
 BEGIN

--- a/sql/CreateTriggers.sql
+++ b/sql/CreateTriggers.sql
@@ -560,6 +560,15 @@ CREATE TRIGGER search_country_area_update AFTER UPDATE OF area ON musicbrainz.co
 CREATE TRIGGER search_country_area_delete BEFORE DELETE ON musicbrainz.country_area
     FOR EACH ROW EXECUTE PROCEDURE search_country_area_delete();
 
+CREATE TRIGGER search_recording_first_release_date_insert AFTER INSERT ON musicbrainz.recording_first_release_date
+    FOR EACH ROW EXECUTE PROCEDURE search_recording_first_release_date_insert();
+
+CREATE TRIGGER search_recording_first_release_date_update AFTER UPDATE OF day, month, recording, year ON musicbrainz.recording_first_release_date
+    FOR EACH ROW EXECUTE PROCEDURE search_recording_first_release_date_update();
+
+CREATE TRIGGER search_recording_first_release_date_delete BEFORE DELETE ON musicbrainz.recording_first_release_date
+    FOR EACH ROW EXECUTE PROCEDURE search_recording_first_release_date_delete();
+
 CREATE TRIGGER search_medium_format_insert AFTER INSERT ON musicbrainz.medium_format
     FOR EACH ROW EXECUTE PROCEDURE search_medium_format_insert();
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to Search Index Rebuilder (SIR).
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/sir/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

SEARCH-218: Add first release date to the web service indexed search results for recordings

It follows MBS-1424.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

This patch adds:
* `first-release-date` to the stored content of `recording` core;
* `firstreleasedate` (advanced) search field to `recording` core.

To make it work, it requires:
* MusicBrainz database with active schema 26 (not released yet), or at least having the table `recording_first_release_date`;
* A (development) version of `mbdata` that supports this table;
* A version of `mb-rngpy` that matches mmd-schema v-2020-11-12.

It goes with PRs metabrainz/mbsssss#54 and metabrainz/mb-solr#46.


# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [X] Update the [WikiDocs pages](https://wiki.musicbrainz.org/Category:WikiDocs_Page) by:
    * [X] adding `firstreleasedate` to searchable fields for `release`:
      * https://wiki.musicbrainz.org/index.php?title=MusicBrainz_API/Search/RecordingSearch&curid=6978&diff=74995&oldid=74554
    * [X] adding `first-release-date` to `release` XML/JSON example results:
      * https://wiki.musicbrainz.org/index.php?title=MusicBrainz_API/Search/RecordingXmlOutput&curid=6979&diff=75003&oldid=74971
      * https://wiki.musicbrainz.org/index.php?title=MusicBrainz_API/Search/RecordingJsonOutput&curid=10033&diff=75004&oldid=74972


# Action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

1. Merge related PR metabrainz/mb-solr#46 too
2. Release both changes at the same time
3. Make updated WikiDocs pages visible on MusicBrainz website:
   * https://musicbrainz.org/doc/Indexed_Search_Syntax
   * https://musicbrainz.org/doc/MusicBrainz_API/Search
