### PR TITLE
SEARCH-319 / SEARCH-384 (indexer): Release group’s first release date

### DIFF
--- a/searchfields.org
+++ b/searchfields.org
@@ -148,7 +148,7 @@ Recording searches can contain you can search:
 *** DONE video
 
 Recording search terms with no fields search the /recording/ field only
-** Release Group [16/16]
+** Release Group [17/17]
 
 The release group index contains the following fields you can search:
 
@@ -157,6 +157,7 @@ The release group index contains the following fields you can search:
 *** DONE artistname
 *** DONE comment
 *** DONE creditname
+*** DONE firstreleasedate
 *** DONE primarytype
 *** DONE rgid
 *** DONE releasegroup

--- a/sir/schema/__init__.py
+++ b/sir/schema/__init__.py
@@ -460,6 +460,7 @@ SearchReleaseGroup = E(modelext.CustomReleaseGroup, [
                 "artist_credit.artists.artist.gid",
                 "artist_credit.artists.artist.sort_name",
                 "artist_credit.artists.artist.comment",
+                "first_release_date.first_release_date",
                 "tags.count", "type.gid",
                 "releases.status.gid",
                 "secondary_types.secondary_type.gid"

--- a/sir/schema/__init__.py
+++ b/sir/schema/__init__.py
@@ -437,6 +437,8 @@ SearchReleaseGroup = E(modelext.CustomReleaseGroup, [
     F("artist", "artist_credit.name"),
     F("artistname", "artist_credit.artists.artist.name"),
     F("creditname", "artist_credit.artists.name"),
+    F("firstreleasedate", "first_release_date.first_release_date",
+      transformfunc=tfs.index_partialdate_to_string),
     F("release", "releases.name"),
     F("reid", "releases.gid"),
     F("releases", "release_count", transformfunc=tfs.integer_sum, trigger=False),
@@ -460,7 +462,6 @@ SearchReleaseGroup = E(modelext.CustomReleaseGroup, [
                 "artist_credit.artists.artist.gid",
                 "artist_credit.artists.artist.sort_name",
                 "artist_credit.artists.artist.comment",
-                "first_release_date.first_release_date",
                 "tags.count", "type.gid",
                 "releases.status.gid",
                 "secondary_types.secondary_type.gid"

--- a/sir/schema/modelext.py
+++ b/sir/schema/modelext.py
@@ -99,6 +99,7 @@ class CustomRecording(Recording):
 
 class CustomReleaseGroup(ReleaseGroup):
     aliases = relationship("ReleaseGroupAlias")
+    first_release_date = relationship("ReleaseGroupMeta")
     releases = relationship("Release")
     tags = relationship("ReleaseGroupTag")
     release_count = column_property(select([func.count(Release.id)]).where(Release.release_group_id == ReleaseGroup.id))

--- a/sir/wscompat/convert.py
+++ b/sir/wscompat/convert.py
@@ -1124,6 +1124,10 @@ def convert_release_group(obj):
                               id=obj.gid, title=obj.name)
     if obj.comment:
         rg.set_disambiguation(obj.comment)
+
+    if obj.meta.first_release_date:
+        rg.set_first_release_date(partialdate_to_string(obj.meta.first_release_date))
+
     if obj.type is not None:
         rg.set_primary_type(convert_release_group_primary_type(obj.type))
         type_ = calculate_type(obj.type, obj.secondary_types)

--- a/sql/CreateFunctions.sql
+++ b/sql/CreateFunctions.sql
@@ -2810,6 +2810,42 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+CREATE OR REPLACE FUNCTION search_release_group_meta_insert() RETURNS trigger
+    AS $$
+BEGIN
+    PERFORM amqp.publish(2, 'search', 'index', (
+            WITH keys(id) AS (SELECT NEW.id)
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_meta"'),
+                             '{_operation}', '"insert"')::text FROM keys
+        ));
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION search_release_group_meta_update() RETURNS trigger
+    AS $$
+BEGIN
+    PERFORM amqp.publish(2, 'search', 'update', (
+            WITH keys(id) AS (SELECT NEW.id)
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_meta"'),
+                             '{_operation}', '"update"')::text FROM keys
+        ));
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION search_release_group_meta_delete() RETURNS trigger
+    AS $$
+BEGIN
+    PERFORM amqp.publish(2, 'search', 'update', (
+            WITH keys(id) AS (SELECT OLD.id)
+            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"release_group_meta"'),
+                             '{_operation}', '"delete"')::text FROM keys
+        ));
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION search_release_group_tag_insert() RETURNS trigger
     AS $$
 BEGIN

--- a/sql/CreateTriggers.sql
+++ b/sql/CreateTriggers.sql
@@ -704,6 +704,15 @@ CREATE TRIGGER search_release_group_alias_update AFTER UPDATE OF name, release_g
 CREATE TRIGGER search_release_group_alias_delete BEFORE DELETE ON musicbrainz.release_group_alias
     FOR EACH ROW EXECUTE PROCEDURE search_release_group_alias_delete();
 
+CREATE TRIGGER search_release_group_meta_insert AFTER INSERT ON musicbrainz.release_group_meta
+    FOR EACH ROW EXECUTE PROCEDURE search_release_group_meta_insert();
+
+CREATE TRIGGER search_release_group_meta_update AFTER UPDATE OF first_release_date_day, first_release_date_month, first_release_date_year, id ON musicbrainz.release_group_meta
+    FOR EACH ROW EXECUTE PROCEDURE search_release_group_meta_update();
+
+CREATE TRIGGER search_release_group_meta_delete BEFORE DELETE ON musicbrainz.release_group_meta
+    FOR EACH ROW EXECUTE PROCEDURE search_release_group_meta_delete();
+
 CREATE TRIGGER search_release_group_tag_insert AFTER INSERT ON musicbrainz.release_group_tag
     FOR EACH ROW EXECUTE PROCEDURE search_release_group_tag_insert();
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to Search Index Rebuilder (SIR).
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/sir/blob/master/CONTRIBUTING.md
-->

# Problems
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

SEARCH-319: Add first release date to the *results* of indexed search for release-groups
SEARCH-384: Add first release date to the *fields* of indexed search for release-groups


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

* Add `first-release-date` to the stored content of `release-group` core.
* Add `firstreleasedate` (advanced) search field to `release-group` core.
  It goes with PRs metabrainz/mbsssss#54 (and metabrainz/mb-solr#46).

# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Update the [WikiDocs pages](https://wiki.musicbrainz.org/Category:WikiDocs_Page) by:
    * [x] adding `firstreleasedate` to searchable fields for `release-group`:
      * https://wiki.musicbrainz.org/index.php?title=MusicBrainz_API/Search/ReleaseGroupSearch&curid=6974&diff=74996&oldid=74564
    * [x] adding `first-release-date` to `release-group` XML/JSON example results:
      * https://wiki.musicbrainz.org/index.php?title=MusicBrainz_API/Search/ReleaseGroupXmlOutput&curid=6975&diff=75001&oldid=74566
      * https://wiki.musicbrainz.org/index.php?title=MusicBrainz_API/Search/ReleaseGroupJsonOutput&curid=10034&diff=75002&oldid=74562

# Action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

1. Merge related PR metabrainz/mb-solr#46 too
2. Release both changes at the same time
3. Make updated WikiDocs pages visible on MusicBrainz website:
   * https://musicbrainz.org/doc/Indexed_Search_Syntax
   * https://musicbrainz.org/doc/MusicBrainz_API/Search
