### PR TITLE
SEARCH-644 (indexer): Stop indexing ordering attribute for series

### DIFF
--- a/searchfields.org
+++ b/searchfields.org
@@ -269,7 +269,6 @@ fields.
 
 *** DONE alias
 *** DONE comment
-*** DONE orderingattribute
 *** DONE series
 *** DONE sid
 *** DONE tag

--- a/sir/schema/__init__.py
+++ b/sir/schema/__init__.py
@@ -473,7 +473,6 @@ SearchSeries = E(modelext.CustomSeries, [
     F("mbid", "gid"),
     F("alias", "aliases.name"),
     F("comment", "comment"),
-    F("orderingattribute", "link_attribute_type.name"),
     F("series", "name"),
     F("tag", "tags.tag.name"),
     F("type", "type.name")

--- a/sir/schema/modelext.py
+++ b/sir/schema/modelext.py
@@ -123,12 +123,6 @@ class CustomReleaseTag(ReleaseTag):
 
 class CustomSeries(Series):
     aliases = relationship("SeriesAlias")
-    link_attribute_type = relationship("LinkAttributeType",
-                                       primaryjoin="\
-                                       CustomSeries.ordering_attribute ==\
-                                       LinkAttributeType.id",
-                                       foreign_keys=Series.ordering_attribute,
-                                       remote_side=LinkAttributeType.id)
     tags = relationship("SeriesTag")
 
 

--- a/sql/CreateFunctions.sql
+++ b/sql/CreateFunctions.sql
@@ -726,7 +726,7 @@ CREATE OR REPLACE FUNCTION search_series_insert() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id, ordering_attribute, ordering_type, type) AS (SELECT NEW.id, NEW.ordering_attribute, NEW.ordering_type, NEW.type)
+            WITH keys(id, ordering_type, type) AS (SELECT NEW.id, NEW.ordering_type, NEW.type)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"series"'),
                              '{_operation}', '"insert"')::text FROM keys
         ));
@@ -738,7 +738,7 @@ CREATE OR REPLACE FUNCTION search_series_update() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id, ordering_attribute, ordering_type, type) AS (SELECT NEW.id, NEW.ordering_attribute, NEW.ordering_type, NEW.type)
+            WITH keys(id, ordering_type, type) AS (SELECT NEW.id, NEW.ordering_type, NEW.type)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"series"'),
                              '{_operation}', '"update"')::text FROM keys
         ));
@@ -750,7 +750,7 @@ CREATE OR REPLACE FUNCTION search_series_delete() RETURNS trigger
     AS $$
 BEGIN
     PERFORM amqp.publish(2, 'search', 'delete', (
-            WITH keys(id, ordering_attribute, ordering_type, type, gid) AS (SELECT OLD.id, OLD.ordering_attribute, OLD.ordering_type, OLD.type, OLD.gid)
+            WITH keys(id, ordering_type, type, gid) AS (SELECT OLD.id, OLD.ordering_type, OLD.type, OLD.gid)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"series"'),
                              '{_operation}', '"delete"')::text FROM keys
         ));
@@ -2912,42 +2912,6 @@ BEGIN
     PERFORM amqp.publish(2, 'search', 'update', (
             WITH keys(id, series, type) AS (SELECT OLD.id, OLD.series, OLD.type)
             SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"series_alias"'),
-                             '{_operation}', '"delete"')::text FROM keys
-        ));
-    RETURN OLD;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE OR REPLACE FUNCTION search_link_attribute_type_insert() RETURNS trigger
-    AS $$
-BEGIN
-    PERFORM amqp.publish(2, 'search', 'index', (
-            WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"link_attribute_type"'),
-                             '{_operation}', '"insert"')::text FROM keys
-        ));
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE OR REPLACE FUNCTION search_link_attribute_type_update() RETURNS trigger
-    AS $$
-BEGIN
-    PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT NEW.id)
-            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"link_attribute_type"'),
-                             '{_operation}', '"update"')::text FROM keys
-        ));
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE OR REPLACE FUNCTION search_link_attribute_type_delete() RETURNS trigger
-    AS $$
-BEGIN
-    PERFORM amqp.publish(2, 'search', 'update', (
-            WITH keys(id) AS (SELECT OLD.id)
-            SELECT jsonb_set(jsonb_set(to_jsonb(keys), '{_table}', '"link_attribute_type"'),
                              '{_operation}', '"delete"')::text FROM keys
         ));
     RETURN OLD;

--- a/sql/CreateTriggers.sql
+++ b/sql/CreateTriggers.sql
@@ -185,7 +185,7 @@ CREATE TRIGGER search_series_annotation_delete BEFORE DELETE ON musicbrainz.seri
 CREATE TRIGGER search_series_insert AFTER INSERT ON musicbrainz.series
     FOR EACH ROW EXECUTE PROCEDURE search_series_insert();
 
-CREATE TRIGGER search_series_update AFTER UPDATE OF comment, gid, name, ordering_attribute, ordering_type, type ON musicbrainz.series
+CREATE TRIGGER search_series_update AFTER UPDATE OF comment, gid, name, ordering_type, type ON musicbrainz.series
     FOR EACH ROW EXECUTE PROCEDURE search_series_update();
 
 CREATE TRIGGER search_series_delete BEFORE DELETE ON musicbrainz.series
@@ -730,15 +730,6 @@ CREATE TRIGGER search_series_alias_update AFTER UPDATE OF begin_date_day, begin_
 
 CREATE TRIGGER search_series_alias_delete BEFORE DELETE ON musicbrainz.series_alias
     FOR EACH ROW EXECUTE PROCEDURE search_series_alias_delete();
-
-CREATE TRIGGER search_link_attribute_type_insert AFTER INSERT ON musicbrainz.link_attribute_type
-    FOR EACH ROW EXECUTE PROCEDURE search_link_attribute_type_insert();
-
-CREATE TRIGGER search_link_attribute_type_update AFTER UPDATE OF gid, name ON musicbrainz.link_attribute_type
-    FOR EACH ROW EXECUTE PROCEDURE search_link_attribute_type_update();
-
-CREATE TRIGGER search_link_attribute_type_delete BEFORE DELETE ON musicbrainz.link_attribute_type
-    FOR EACH ROW EXECUTE PROCEDURE search_link_attribute_type_delete();
 
 CREATE TRIGGER search_series_tag_insert AFTER INSERT ON musicbrainz.series_tag
     FOR EACH ROW EXECUTE PROCEDURE search_series_tag_insert();


### PR DESCRIPTION
# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

SEARCH-644: Remove unintented ordering attribute from series index


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

This pull request stops filling this search field.

It also has to be removed it from search schema, see metabrainz/mbsssss#58.


# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] No WikiDocs to be updated as this field was not documented


# Action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

1. Deploy metabrainz/mbsssss#58
2. Deploy this pull request
3. Rebuild `series` search index
