### PR TITLE
SEARCH-642 (indexer): Drop id fields for cdstub and tag

### DIFF
--- a/sir/schema/__init__.py
+++ b/sir/schema/__init__.py
@@ -139,7 +139,6 @@ SearchArtist = E(modelext.CustomArtist, [
 
 
 SearchCDStub = E(modelext.CustomReleaseRaw, [
-    F("id", "id"),
     F("title", "title"),
     F("artist", "artist"),
     F("comment", "comment"),
@@ -489,7 +488,6 @@ SearchSeries = E(modelext.CustomSeries, [
 
 
 SearchTag = E(models.Tag, [
-    F("id", "id"),
     F("tag", "name")
 ],
     1.5,


### PR DESCRIPTION
# Problem
SEARCH-642.

These are not the unique identifiers we use and are not exposed.
For cdstub we expose unique discid, for tag unique name.

# Solution
This pull request stops filling this search field.

It also has to be removed it from search schema, see https://github.com/metabrainz/mbsssss/pull/59

# Checklist for author

* [x] Remove the fields from the documentation.

# Action

Deploy https://github.com/metabrainz/mbsssss/pull/59
Deploy this pull request
Rebuild cdstub and tag search indexes
