### PR TITLE
Support RABBITMQ_SERVICE environment variable

### DIFF
--- a/config.ini.ctmpl
+++ b/config.ini.ctmpl
@@ -30,15 +30,17 @@ user = {{template "KEY" "db/user"}}
 uri = {{template "KEY" "solr/uri"}}
 batch_size = {{template "KEY" "solr/batch_size"}}
 
-{{- if service "rabbitmq"}}
+{{- with $rabbitmq_service_name := or (env "RABBITMQ_SERVICE") "rabbitmq"}}
+{{- if service $rabbitmq_service_name}}
 [rabbitmq]
-{{- with index (service "rabbitmq") 0}}
+{{- with index (service $rabbitmq_service_name) 0}}
 host = {{.Address}}:{{.Port}}
 user = {{template "KEY" "rabbitmq/user"}}
 password = {{template "KEY" "rabbitmq/password"}}
 vhost = {{template "KEY" "rabbitmq/vhost"}}
 prefetch_count = {{template "KEY" "rabbitmq/prefetch_count"}}
 timeout = {{template "KEY" "rabbitmq/timeout"}}
+{{- end}}
 {{- end}}
 {{- end}}
 


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to Search Index Rebuilder (SIR).
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/sir/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

SIR container cannot be set to use a different service name than `rabbitmq` for RabbitMQ.

This is needed to switch to another instance of RabbitMQ. It helps with migrating RabbitMQ without interruption.


# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Use `RABBITMQ_SERVICE` container environment variable if available, or fallback to the current `rabbitmq`.