### PR TITLE
Check for errno attribute before access

### DIFF
--- a/sir/amqp/handler.py
+++ b/sir/amqp/handler.py
@@ -459,7 +459,7 @@ def _watch_impl():
                 pass
             except Exception as exc:
                 # Do not log system call interruption in case of SIGTERM or SIGINT
-                if exc.errno != errno.EINTR:
+                if not hasattr(exc, 'errno') or exc.errno != errno.EINTR:
                     logger.error(format_exc(exc))
             if indexing.PROCESS_FLAG.value:
                 if ((time.time() - handler.last_message) >= handler.process_delay


### PR DESCRIPTION
The except clause in question checks for the errno attribute of caught Exceptions but not all exceptions have a errno attribute. For instance, PreconditionFailed exception raised by AMQP does have it. Hence, check for the attribute before access.

https://sentry.metabrainz.org/metabrainz/sir/issues/105011/