### PR TITLE
Update psql install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,9 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # PostgreSQL client
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
-ENV PG_MAJOR 9.5
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
+RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+ENV PG_MAJOR 12
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
 RUN apt-get update && \
     apt-get install -y postgresql-client-$PG_MAJOR && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The keyserver ha.pool.sks-keyservers.net is no loger available. Also, the jessie repo is unavailable. We have faced similar issues in various PythonBrainz projects before. For instance: https://github.com/metabrainz/critiquebrainz/pull/375 and https://github.com/metabrainz/listenbrainz-server/pull/1427 . Applying the same fix here.