### PR TITLE
Fix image build and update some dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN mkdir -p /usr/local/share/keyrings && \
     gpg --no-default-keyring --keyring /tmp/postgres-keyring.gpg --import /tmp/postgres-key.asc && \
     gpg --no-default-keyring --keyring /tmp/postgres-keyring.gpg --export --output /usr/local/share/keyrings/apt.postgresql.org.gpg && \
     rm -f /tmp/postgres-key.asc /tmp/postgres-keyring.gpg
-ENV PG_MAJOR 9.5
+ENV PG_MAJOR 12
 RUN echo 'deb [signed-by=/usr/local/share/keyrings/apt.postgresql.org.gpg] http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
 RUN apt-get update && \
     apt-get install -y postgresql-client-$PG_MAJOR && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,9 @@ RUN apt-get update && \
                     build-essential \
                     ca-certificates \
                     cron \
+                    curl \
                     git \
+                    gnupg \
                     libpq-dev \
                     libffi-dev \
                     libssl-dev \
@@ -32,9 +34,13 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # PostgreSQL client
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
+RUN mkdir -p /usr/local/share/keyrings && \
+    curl -sSL --retry 5 https://www.postgresql.org/media/keys/ACCC4CF8.asc > /tmp/postgres-key.asc && \
+    gpg --no-default-keyring --keyring /tmp/postgres-keyring.gpg --import /tmp/postgres-key.asc && \
+    gpg --no-default-keyring --keyring /tmp/postgres-keyring.gpg --export --output /usr/local/share/keyrings/apt.postgresql.org.gpg && \
+    rm -f /tmp/postgres-key.asc /tmp/postgres-keyring.gpg
 ENV PG_MAJOR 9.5
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
+RUN echo 'deb [signed-by=/usr/local/share/keyrings/apt.postgresql.org.gpg] http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
 RUN apt-get update && \
     apt-get install -y postgresql-client-$PG_MAJOR && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG PYTHON_VERSION=2.7
-ARG BASE_IMAGE_DATE=20201201
+ARG BASE_IMAGE_DATE=20210517
 FROM metabrainz/python:$PYTHON_VERSION-$BASE_IMAGE_DATE
 
 ARG SIR_VERSION
@@ -40,7 +40,7 @@ RUN mkdir -p /usr/local/share/keyrings && \
     gpg --no-default-keyring --keyring /tmp/postgres-keyring.gpg --export --output /usr/local/share/keyrings/apt.postgresql.org.gpg && \
     rm -f /tmp/postgres-key.asc /tmp/postgres-keyring.gpg
 ENV PG_MAJOR 12
-RUN echo 'deb [signed-by=/usr/local/share/keyrings/apt.postgresql.org.gpg] http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
+RUN echo 'deb [signed-by=/usr/local/share/keyrings/apt.postgresql.org.gpg] http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
 RUN apt-get update && \
     apt-get install -y postgresql-client-$PG_MAJOR && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM metabrainz/python:2.7-20201201
+FROM metabrainz/python:2.7-20210517
 
 RUN mkdir /code
 WORKDIR /code

--- a/docker/prod/consul-template.conf
+++ b/docker/prod/consul-template.conf
@@ -1,5 +1,8 @@
 template {
     source = "/code/config.ini.ctmpl"
     destination = "/code/config.ini"
-    command = "sv restart indexer"
+}
+
+exec {
+    command = "python -m sir amqp_watch"
 }

--- a/docker/prod/indexer/indexer.service
+++ b/docker/prod/indexer/indexer.service
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 cd /code
-exec python -m sir amqp_watch
+exec run-consul-template -config /etc/consul-template.conf


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to Search Index Rebuilder (SIR).
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/sir/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

- Image build was broken since the `jessie-pdpg` distribution of PostgreSQL has been discontinued.
- Not a showstopper but it also relied on an outdated base image and outdated dependencies.
- Last it was still using `apt-key` which is deprecated since 2021 for security reasons.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

- Switch to the latest Docker base image for Python 2 at MetaBrainz: `2.7-20210517;
  * Update the configuration of Consul Template to work with the version `0.25.2`;
  * To actually unblock image build: Refer to `focal-pdpg` for PostgreSQL distribution;
- Update PostgreSQL client to the version `12` (already used by MusicBrainz Server);
- Replace using `apt-key` with `curl`/`gpg` to generate safer `sources.list`;

# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Tested with a consul setup (at `test.musicbrainz.org`)
* [x] Tested with `musicbrainz-docker` (which is consul-free)