### PR TITLE
SEARCH-609: Triggers only fire message on data change

### DIFF
--- a/sir/trigger_generation/sql_generator.py
+++ b/sir/trigger_generation/sql_generator.py
@@ -163,6 +163,12 @@ class UpdateTriggerGenerator(TriggerGenerator):
         # in case any FK of related tables are changed
         all_columns = sorted(set(self.fk_columns + list(self.update_columns)))
         operation = "UPDATE OF %s" % ", ".join(all_columns)
+        # Compare all columns but 'coordinates' because its data type 'point'
+        # has no comparison operator '=' (only '=~') to use with 'DISTINCT'.
+        try:
+            all_columns.remove('coordinates');
+        except ValueError as e:
+            pass
         old = ", ".join(['OLD.{column}'.format(column=column) for column in all_columns])
         new = ", ".join(['NEW.{column}'.format(column=column) for column in all_columns])
         when = "({old}) IS DISTINCT FROM ({new})".format(old=old, new=new)

--- a/sir/trigger_generation/sql_generator.py
+++ b/sir/trigger_generation/sql_generator.py
@@ -157,7 +157,7 @@ class UpdateTriggerGenerator(TriggerGenerator):
         """
 
         if not self.update_columns:
-            return super().triger()
+            return super().trigger()
 
         # Consider FK columns in update triggers to make sure triggers are fired
         # in case any FK of related tables are changed

--- a/sql/CreateTriggers.sql
+++ b/sql/CreateTriggers.sql
@@ -6,7 +6,9 @@ CREATE TRIGGER search_annotation_insert AFTER INSERT ON musicbrainz.annotation
     FOR EACH ROW EXECUTE PROCEDURE search_annotation_insert();
 
 CREATE TRIGGER search_annotation_update AFTER UPDATE OF editor, id, text ON musicbrainz.annotation
-    FOR EACH ROW EXECUTE PROCEDURE search_annotation_update();
+    FOR EACH ROW
+    WHEN ((OLD.editor, OLD.id, OLD.text) IS DISTINCT FROM (NEW.editor, NEW.id, NEW.text))
+    EXECUTE PROCEDURE search_annotation_update();
 
 CREATE TRIGGER search_annotation_delete BEFORE DELETE ON musicbrainz.annotation
     FOR EACH ROW EXECUTE PROCEDURE search_annotation_delete();
@@ -15,7 +17,9 @@ CREATE TRIGGER search_area_annotation_insert AFTER INSERT ON musicbrainz.area_an
     FOR EACH ROW EXECUTE PROCEDURE search_area_annotation_insert();
 
 CREATE TRIGGER search_area_annotation_update AFTER UPDATE OF annotation, area ON musicbrainz.area_annotation
-    FOR EACH ROW EXECUTE PROCEDURE search_area_annotation_update();
+    FOR EACH ROW
+    WHEN ((OLD.annotation, OLD.area) IS DISTINCT FROM (NEW.annotation, NEW.area))
+    EXECUTE PROCEDURE search_area_annotation_update();
 
 CREATE TRIGGER search_area_annotation_delete BEFORE DELETE ON musicbrainz.area_annotation
     FOR EACH ROW EXECUTE PROCEDURE search_area_annotation_delete();
@@ -24,7 +28,9 @@ CREATE TRIGGER search_area_insert AFTER INSERT ON musicbrainz.area
     FOR EACH ROW EXECUTE PROCEDURE search_area_insert();
 
 CREATE TRIGGER search_area_update AFTER UPDATE OF begin_date_day, begin_date_month, begin_date_year, comment, end_date_day, end_date_month, end_date_year, ended, gid, name, type ON musicbrainz.area
-    FOR EACH ROW EXECUTE PROCEDURE search_area_update();
+    FOR EACH ROW
+    WHEN ((OLD.begin_date_day, OLD.begin_date_month, OLD.begin_date_year, OLD.comment, OLD.end_date_day, OLD.end_date_month, OLD.end_date_year, OLD.ended, OLD.gid, OLD.name, OLD.type) IS DISTINCT FROM (NEW.begin_date_day, NEW.begin_date_month, NEW.begin_date_year, NEW.comment, NEW.end_date_day, NEW.end_date_month, NEW.end_date_year, NEW.ended, NEW.gid, NEW.name, NEW.type))
+    EXECUTE PROCEDURE search_area_update();
 
 CREATE TRIGGER search_area_delete BEFORE DELETE ON musicbrainz.area
     FOR EACH ROW EXECUTE PROCEDURE search_area_delete();
@@ -33,7 +39,9 @@ CREATE TRIGGER search_artist_annotation_insert AFTER INSERT ON musicbrainz.artis
     FOR EACH ROW EXECUTE PROCEDURE search_artist_annotation_insert();
 
 CREATE TRIGGER search_artist_annotation_update AFTER UPDATE OF annotation, artist ON musicbrainz.artist_annotation
-    FOR EACH ROW EXECUTE PROCEDURE search_artist_annotation_update();
+    FOR EACH ROW
+    WHEN ((OLD.annotation, OLD.artist) IS DISTINCT FROM (NEW.annotation, NEW.artist))
+    EXECUTE PROCEDURE search_artist_annotation_update();
 
 CREATE TRIGGER search_artist_annotation_delete BEFORE DELETE ON musicbrainz.artist_annotation
     FOR EACH ROW EXECUTE PROCEDURE search_artist_annotation_delete();
@@ -42,7 +50,9 @@ CREATE TRIGGER search_artist_insert AFTER INSERT ON musicbrainz.artist
     FOR EACH ROW EXECUTE PROCEDURE search_artist_insert();
 
 CREATE TRIGGER search_artist_update AFTER UPDATE OF area, begin_area, begin_date_day, begin_date_month, begin_date_year, comment, end_area, end_date_day, end_date_month, end_date_year, ended, gender, gid, name, sort_name, type ON musicbrainz.artist
-    FOR EACH ROW EXECUTE PROCEDURE search_artist_update();
+    FOR EACH ROW
+    WHEN ((OLD.area, OLD.begin_area, OLD.begin_date_day, OLD.begin_date_month, OLD.begin_date_year, OLD.comment, OLD.end_area, OLD.end_date_day, OLD.end_date_month, OLD.end_date_year, OLD.ended, OLD.gender, OLD.gid, OLD.name, OLD.sort_name, OLD.type) IS DISTINCT FROM (NEW.area, NEW.begin_area, NEW.begin_date_day, NEW.begin_date_month, NEW.begin_date_year, NEW.comment, NEW.end_area, NEW.end_date_day, NEW.end_date_month, NEW.end_date_year, NEW.ended, NEW.gender, NEW.gid, NEW.name, NEW.sort_name, NEW.type))
+    EXECUTE PROCEDURE search_artist_update();
 
 CREATE TRIGGER search_artist_delete BEFORE DELETE ON musicbrainz.artist
     FOR EACH ROW EXECUTE PROCEDURE search_artist_delete();
@@ -51,7 +61,9 @@ CREATE TRIGGER search_event_annotation_insert AFTER INSERT ON musicbrainz.event_
     FOR EACH ROW EXECUTE PROCEDURE search_event_annotation_insert();
 
 CREATE TRIGGER search_event_annotation_update AFTER UPDATE OF annotation, event ON musicbrainz.event_annotation
-    FOR EACH ROW EXECUTE PROCEDURE search_event_annotation_update();
+    FOR EACH ROW
+    WHEN ((OLD.annotation, OLD.event) IS DISTINCT FROM (NEW.annotation, NEW.event))
+    EXECUTE PROCEDURE search_event_annotation_update();
 
 CREATE TRIGGER search_event_annotation_delete BEFORE DELETE ON musicbrainz.event_annotation
     FOR EACH ROW EXECUTE PROCEDURE search_event_annotation_delete();
@@ -60,7 +72,9 @@ CREATE TRIGGER search_event_insert AFTER INSERT ON musicbrainz.event
     FOR EACH ROW EXECUTE PROCEDURE search_event_insert();
 
 CREATE TRIGGER search_event_update AFTER UPDATE OF begin_date_day, begin_date_month, begin_date_year, comment, end_date_day, end_date_month, end_date_year, ended, gid, name, time, type ON musicbrainz.event
-    FOR EACH ROW EXECUTE PROCEDURE search_event_update();
+    FOR EACH ROW
+    WHEN ((OLD.begin_date_day, OLD.begin_date_month, OLD.begin_date_year, OLD.comment, OLD.end_date_day, OLD.end_date_month, OLD.end_date_year, OLD.ended, OLD.gid, OLD.name, OLD.time, OLD.type) IS DISTINCT FROM (NEW.begin_date_day, NEW.begin_date_month, NEW.begin_date_year, NEW.comment, NEW.end_date_day, NEW.end_date_month, NEW.end_date_year, NEW.ended, NEW.gid, NEW.name, NEW.time, NEW.type))
+    EXECUTE PROCEDURE search_event_update();
 
 CREATE TRIGGER search_event_delete BEFORE DELETE ON musicbrainz.event
     FOR EACH ROW EXECUTE PROCEDURE search_event_delete();
@@ -69,7 +83,9 @@ CREATE TRIGGER search_instrument_annotation_insert AFTER INSERT ON musicbrainz.i
     FOR EACH ROW EXECUTE PROCEDURE search_instrument_annotation_insert();
 
 CREATE TRIGGER search_instrument_annotation_update AFTER UPDATE OF annotation, instrument ON musicbrainz.instrument_annotation
-    FOR EACH ROW EXECUTE PROCEDURE search_instrument_annotation_update();
+    FOR EACH ROW
+    WHEN ((OLD.annotation, OLD.instrument) IS DISTINCT FROM (NEW.annotation, NEW.instrument))
+    EXECUTE PROCEDURE search_instrument_annotation_update();
 
 CREATE TRIGGER search_instrument_annotation_delete BEFORE DELETE ON musicbrainz.instrument_annotation
     FOR EACH ROW EXECUTE PROCEDURE search_instrument_annotation_delete();
@@ -78,7 +94,9 @@ CREATE TRIGGER search_instrument_insert AFTER INSERT ON musicbrainz.instrument
     FOR EACH ROW EXECUTE PROCEDURE search_instrument_insert();
 
 CREATE TRIGGER search_instrument_update AFTER UPDATE OF comment, description, gid, name, type ON musicbrainz.instrument
-    FOR EACH ROW EXECUTE PROCEDURE search_instrument_update();
+    FOR EACH ROW
+    WHEN ((OLD.comment, OLD.description, OLD.gid, OLD.name, OLD.type) IS DISTINCT FROM (NEW.comment, NEW.description, NEW.gid, NEW.name, NEW.type))
+    EXECUTE PROCEDURE search_instrument_update();
 
 CREATE TRIGGER search_instrument_delete BEFORE DELETE ON musicbrainz.instrument
     FOR EACH ROW EXECUTE PROCEDURE search_instrument_delete();
@@ -87,7 +105,9 @@ CREATE TRIGGER search_label_annotation_insert AFTER INSERT ON musicbrainz.label_
     FOR EACH ROW EXECUTE PROCEDURE search_label_annotation_insert();
 
 CREATE TRIGGER search_label_annotation_update AFTER UPDATE OF annotation, label ON musicbrainz.label_annotation
-    FOR EACH ROW EXECUTE PROCEDURE search_label_annotation_update();
+    FOR EACH ROW
+    WHEN ((OLD.annotation, OLD.label) IS DISTINCT FROM (NEW.annotation, NEW.label))
+    EXECUTE PROCEDURE search_label_annotation_update();
 
 CREATE TRIGGER search_label_annotation_delete BEFORE DELETE ON musicbrainz.label_annotation
     FOR EACH ROW EXECUTE PROCEDURE search_label_annotation_delete();
@@ -96,7 +116,9 @@ CREATE TRIGGER search_label_insert AFTER INSERT ON musicbrainz.label
     FOR EACH ROW EXECUTE PROCEDURE search_label_insert();
 
 CREATE TRIGGER search_label_update AFTER UPDATE OF area, begin_date_day, begin_date_month, begin_date_year, comment, end_date_day, end_date_month, end_date_year, ended, gid, label_code, name, type ON musicbrainz.label
-    FOR EACH ROW EXECUTE PROCEDURE search_label_update();
+    FOR EACH ROW
+    WHEN ((OLD.area, OLD.begin_date_day, OLD.begin_date_month, OLD.begin_date_year, OLD.comment, OLD.end_date_day, OLD.end_date_month, OLD.end_date_year, OLD.ended, OLD.gid, OLD.label_code, OLD.name, OLD.type) IS DISTINCT FROM (NEW.area, NEW.begin_date_day, NEW.begin_date_month, NEW.begin_date_year, NEW.comment, NEW.end_date_day, NEW.end_date_month, NEW.end_date_year, NEW.ended, NEW.gid, NEW.label_code, NEW.name, NEW.type))
+    EXECUTE PROCEDURE search_label_update();
 
 CREATE TRIGGER search_label_delete BEFORE DELETE ON musicbrainz.label
     FOR EACH ROW EXECUTE PROCEDURE search_label_delete();
@@ -105,7 +127,9 @@ CREATE TRIGGER search_place_annotation_insert AFTER INSERT ON musicbrainz.place_
     FOR EACH ROW EXECUTE PROCEDURE search_place_annotation_insert();
 
 CREATE TRIGGER search_place_annotation_update AFTER UPDATE OF annotation, place ON musicbrainz.place_annotation
-    FOR EACH ROW EXECUTE PROCEDURE search_place_annotation_update();
+    FOR EACH ROW
+    WHEN ((OLD.annotation, OLD.place) IS DISTINCT FROM (NEW.annotation, NEW.place))
+    EXECUTE PROCEDURE search_place_annotation_update();
 
 CREATE TRIGGER search_place_annotation_delete BEFORE DELETE ON musicbrainz.place_annotation
     FOR EACH ROW EXECUTE PROCEDURE search_place_annotation_delete();
@@ -114,7 +138,9 @@ CREATE TRIGGER search_place_insert AFTER INSERT ON musicbrainz.place
     FOR EACH ROW EXECUTE PROCEDURE search_place_insert();
 
 CREATE TRIGGER search_place_update AFTER UPDATE OF address, area, begin_date_day, begin_date_month, begin_date_year, comment, coordinates, end_date_day, end_date_month, end_date_year, ended, gid, name, type ON musicbrainz.place
-    FOR EACH ROW EXECUTE PROCEDURE search_place_update();
+    FOR EACH ROW
+    WHEN ((OLD.address, OLD.area, OLD.begin_date_day, OLD.begin_date_month, OLD.begin_date_year, OLD.comment, OLD.end_date_day, OLD.end_date_month, OLD.end_date_year, OLD.ended, OLD.gid, OLD.name, OLD.type) IS DISTINCT FROM (NEW.address, NEW.area, NEW.begin_date_day, NEW.begin_date_month, NEW.begin_date_year, NEW.comment, NEW.end_date_day, NEW.end_date_month, NEW.end_date_year, NEW.ended, NEW.gid, NEW.name, NEW.type))
+    EXECUTE PROCEDURE search_place_update();
 
 CREATE TRIGGER search_place_delete BEFORE DELETE ON musicbrainz.place
     FOR EACH ROW EXECUTE PROCEDURE search_place_delete();
@@ -123,7 +149,9 @@ CREATE TRIGGER search_recording_annotation_insert AFTER INSERT ON musicbrainz.re
     FOR EACH ROW EXECUTE PROCEDURE search_recording_annotation_insert();
 
 CREATE TRIGGER search_recording_annotation_update AFTER UPDATE OF annotation, recording ON musicbrainz.recording_annotation
-    FOR EACH ROW EXECUTE PROCEDURE search_recording_annotation_update();
+    FOR EACH ROW
+    WHEN ((OLD.annotation, OLD.recording) IS DISTINCT FROM (NEW.annotation, NEW.recording))
+    EXECUTE PROCEDURE search_recording_annotation_update();
 
 CREATE TRIGGER search_recording_annotation_delete BEFORE DELETE ON musicbrainz.recording_annotation
     FOR EACH ROW EXECUTE PROCEDURE search_recording_annotation_delete();
@@ -132,7 +160,9 @@ CREATE TRIGGER search_recording_insert AFTER INSERT ON musicbrainz.recording
     FOR EACH ROW EXECUTE PROCEDURE search_recording_insert();
 
 CREATE TRIGGER search_recording_update AFTER UPDATE OF artist_credit, comment, gid, length, name, video ON musicbrainz.recording
-    FOR EACH ROW EXECUTE PROCEDURE search_recording_update();
+    FOR EACH ROW
+    WHEN ((OLD.artist_credit, OLD.comment, OLD.gid, OLD.length, OLD.name, OLD.video) IS DISTINCT FROM (NEW.artist_credit, NEW.comment, NEW.gid, NEW.length, NEW.name, NEW.video))
+    EXECUTE PROCEDURE search_recording_update();
 
 CREATE TRIGGER search_recording_delete BEFORE DELETE ON musicbrainz.recording
     FOR EACH ROW EXECUTE PROCEDURE search_recording_delete();
@@ -141,7 +171,9 @@ CREATE TRIGGER search_release_annotation_insert AFTER INSERT ON musicbrainz.rele
     FOR EACH ROW EXECUTE PROCEDURE search_release_annotation_insert();
 
 CREATE TRIGGER search_release_annotation_update AFTER UPDATE OF annotation, release ON musicbrainz.release_annotation
-    FOR EACH ROW EXECUTE PROCEDURE search_release_annotation_update();
+    FOR EACH ROW
+    WHEN ((OLD.annotation, OLD.release) IS DISTINCT FROM (NEW.annotation, NEW.release))
+    EXECUTE PROCEDURE search_release_annotation_update();
 
 CREATE TRIGGER search_release_annotation_delete BEFORE DELETE ON musicbrainz.release_annotation
     FOR EACH ROW EXECUTE PROCEDURE search_release_annotation_delete();
@@ -150,7 +182,9 @@ CREATE TRIGGER search_release_insert AFTER INSERT ON musicbrainz.release
     FOR EACH ROW EXECUTE PROCEDURE search_release_insert();
 
 CREATE TRIGGER search_release_update AFTER UPDATE OF artist_credit, barcode, comment, gid, language, name, packaging, quality, release_group, script, status ON musicbrainz.release
-    FOR EACH ROW EXECUTE PROCEDURE search_release_update();
+    FOR EACH ROW
+    WHEN ((OLD.artist_credit, OLD.barcode, OLD.comment, OLD.gid, OLD.language, OLD.name, OLD.packaging, OLD.quality, OLD.release_group, OLD.script, OLD.status) IS DISTINCT FROM (NEW.artist_credit, NEW.barcode, NEW.comment, NEW.gid, NEW.language, NEW.name, NEW.packaging, NEW.quality, NEW.release_group, NEW.script, NEW.status))
+    EXECUTE PROCEDURE search_release_update();
 
 CREATE TRIGGER search_release_delete BEFORE DELETE ON musicbrainz.release
     FOR EACH ROW EXECUTE PROCEDURE search_release_delete();
@@ -159,7 +193,9 @@ CREATE TRIGGER search_release_group_annotation_insert AFTER INSERT ON musicbrain
     FOR EACH ROW EXECUTE PROCEDURE search_release_group_annotation_insert();
 
 CREATE TRIGGER search_release_group_annotation_update AFTER UPDATE OF annotation, release_group ON musicbrainz.release_group_annotation
-    FOR EACH ROW EXECUTE PROCEDURE search_release_group_annotation_update();
+    FOR EACH ROW
+    WHEN ((OLD.annotation, OLD.release_group) IS DISTINCT FROM (NEW.annotation, NEW.release_group))
+    EXECUTE PROCEDURE search_release_group_annotation_update();
 
 CREATE TRIGGER search_release_group_annotation_delete BEFORE DELETE ON musicbrainz.release_group_annotation
     FOR EACH ROW EXECUTE PROCEDURE search_release_group_annotation_delete();
@@ -168,7 +204,9 @@ CREATE TRIGGER search_release_group_insert AFTER INSERT ON musicbrainz.release_g
     FOR EACH ROW EXECUTE PROCEDURE search_release_group_insert();
 
 CREATE TRIGGER search_release_group_update AFTER UPDATE OF artist_credit, comment, gid, name, type ON musicbrainz.release_group
-    FOR EACH ROW EXECUTE PROCEDURE search_release_group_update();
+    FOR EACH ROW
+    WHEN ((OLD.artist_credit, OLD.comment, OLD.gid, OLD.name, OLD.type) IS DISTINCT FROM (NEW.artist_credit, NEW.comment, NEW.gid, NEW.name, NEW.type))
+    EXECUTE PROCEDURE search_release_group_update();
 
 CREATE TRIGGER search_release_group_delete BEFORE DELETE ON musicbrainz.release_group
     FOR EACH ROW EXECUTE PROCEDURE search_release_group_delete();
@@ -177,7 +215,9 @@ CREATE TRIGGER search_series_annotation_insert AFTER INSERT ON musicbrainz.serie
     FOR EACH ROW EXECUTE PROCEDURE search_series_annotation_insert();
 
 CREATE TRIGGER search_series_annotation_update AFTER UPDATE OF annotation, series ON musicbrainz.series_annotation
-    FOR EACH ROW EXECUTE PROCEDURE search_series_annotation_update();
+    FOR EACH ROW
+    WHEN ((OLD.annotation, OLD.series) IS DISTINCT FROM (NEW.annotation, NEW.series))
+    EXECUTE PROCEDURE search_series_annotation_update();
 
 CREATE TRIGGER search_series_annotation_delete BEFORE DELETE ON musicbrainz.series_annotation
     FOR EACH ROW EXECUTE PROCEDURE search_series_annotation_delete();
@@ -186,7 +226,9 @@ CREATE TRIGGER search_series_insert AFTER INSERT ON musicbrainz.series
     FOR EACH ROW EXECUTE PROCEDURE search_series_insert();
 
 CREATE TRIGGER search_series_update AFTER UPDATE OF comment, gid, name, ordering_type, type ON musicbrainz.series
-    FOR EACH ROW EXECUTE PROCEDURE search_series_update();
+    FOR EACH ROW
+    WHEN ((OLD.comment, OLD.gid, OLD.name, OLD.ordering_type, OLD.type) IS DISTINCT FROM (NEW.comment, NEW.gid, NEW.name, NEW.ordering_type, NEW.type))
+    EXECUTE PROCEDURE search_series_update();
 
 CREATE TRIGGER search_series_delete BEFORE DELETE ON musicbrainz.series
     FOR EACH ROW EXECUTE PROCEDURE search_series_delete();
@@ -195,7 +237,9 @@ CREATE TRIGGER search_work_annotation_insert AFTER INSERT ON musicbrainz.work_an
     FOR EACH ROW EXECUTE PROCEDURE search_work_annotation_insert();
 
 CREATE TRIGGER search_work_annotation_update AFTER UPDATE OF annotation, work ON musicbrainz.work_annotation
-    FOR EACH ROW EXECUTE PROCEDURE search_work_annotation_update();
+    FOR EACH ROW
+    WHEN ((OLD.annotation, OLD.work) IS DISTINCT FROM (NEW.annotation, NEW.work))
+    EXECUTE PROCEDURE search_work_annotation_update();
 
 CREATE TRIGGER search_work_annotation_delete BEFORE DELETE ON musicbrainz.work_annotation
     FOR EACH ROW EXECUTE PROCEDURE search_work_annotation_delete();
@@ -204,7 +248,9 @@ CREATE TRIGGER search_work_insert AFTER INSERT ON musicbrainz.work
     FOR EACH ROW EXECUTE PROCEDURE search_work_insert();
 
 CREATE TRIGGER search_work_update AFTER UPDATE OF comment, gid, name, type ON musicbrainz.work
-    FOR EACH ROW EXECUTE PROCEDURE search_work_update();
+    FOR EACH ROW
+    WHEN ((OLD.comment, OLD.gid, OLD.name, OLD.type) IS DISTINCT FROM (NEW.comment, NEW.gid, NEW.name, NEW.type))
+    EXECUTE PROCEDURE search_work_update();
 
 CREATE TRIGGER search_work_delete BEFORE DELETE ON musicbrainz.work
     FOR EACH ROW EXECUTE PROCEDURE search_work_delete();
@@ -213,7 +259,9 @@ CREATE TRIGGER search_area_alias_insert AFTER INSERT ON musicbrainz.area_alias
     FOR EACH ROW EXECUTE PROCEDURE search_area_alias_insert();
 
 CREATE TRIGGER search_area_alias_update AFTER UPDATE OF area, begin_date_day, begin_date_month, begin_date_year, end_date_day, end_date_month, end_date_year, locale, name, primary_for_locale, sort_name, type ON musicbrainz.area_alias
-    FOR EACH ROW EXECUTE PROCEDURE search_area_alias_update();
+    FOR EACH ROW
+    WHEN ((OLD.area, OLD.begin_date_day, OLD.begin_date_month, OLD.begin_date_year, OLD.end_date_day, OLD.end_date_month, OLD.end_date_year, OLD.locale, OLD.name, OLD.primary_for_locale, OLD.sort_name, OLD.type) IS DISTINCT FROM (NEW.area, NEW.begin_date_day, NEW.begin_date_month, NEW.begin_date_year, NEW.end_date_day, NEW.end_date_month, NEW.end_date_year, NEW.locale, NEW.name, NEW.primary_for_locale, NEW.sort_name, NEW.type))
+    EXECUTE PROCEDURE search_area_alias_update();
 
 CREATE TRIGGER search_area_alias_delete BEFORE DELETE ON musicbrainz.area_alias
     FOR EACH ROW EXECUTE PROCEDURE search_area_alias_delete();
@@ -222,7 +270,9 @@ CREATE TRIGGER search_iso_3166_1_insert AFTER INSERT ON musicbrainz.iso_3166_1
     FOR EACH ROW EXECUTE PROCEDURE search_iso_3166_1_insert();
 
 CREATE TRIGGER search_iso_3166_1_update AFTER UPDATE OF area, code ON musicbrainz.iso_3166_1
-    FOR EACH ROW EXECUTE PROCEDURE search_iso_3166_1_update();
+    FOR EACH ROW
+    WHEN ((OLD.area, OLD.code) IS DISTINCT FROM (NEW.area, NEW.code))
+    EXECUTE PROCEDURE search_iso_3166_1_update();
 
 CREATE TRIGGER search_iso_3166_1_delete BEFORE DELETE ON musicbrainz.iso_3166_1
     FOR EACH ROW EXECUTE PROCEDURE search_iso_3166_1_delete();
@@ -231,7 +281,9 @@ CREATE TRIGGER search_iso_3166_2_insert AFTER INSERT ON musicbrainz.iso_3166_2
     FOR EACH ROW EXECUTE PROCEDURE search_iso_3166_2_insert();
 
 CREATE TRIGGER search_iso_3166_2_update AFTER UPDATE OF area, code ON musicbrainz.iso_3166_2
-    FOR EACH ROW EXECUTE PROCEDURE search_iso_3166_2_update();
+    FOR EACH ROW
+    WHEN ((OLD.area, OLD.code) IS DISTINCT FROM (NEW.area, NEW.code))
+    EXECUTE PROCEDURE search_iso_3166_2_update();
 
 CREATE TRIGGER search_iso_3166_2_delete BEFORE DELETE ON musicbrainz.iso_3166_2
     FOR EACH ROW EXECUTE PROCEDURE search_iso_3166_2_delete();
@@ -240,7 +292,9 @@ CREATE TRIGGER search_iso_3166_3_insert AFTER INSERT ON musicbrainz.iso_3166_3
     FOR EACH ROW EXECUTE PROCEDURE search_iso_3166_3_insert();
 
 CREATE TRIGGER search_iso_3166_3_update AFTER UPDATE OF area, code ON musicbrainz.iso_3166_3
-    FOR EACH ROW EXECUTE PROCEDURE search_iso_3166_3_update();
+    FOR EACH ROW
+    WHEN ((OLD.area, OLD.code) IS DISTINCT FROM (NEW.area, NEW.code))
+    EXECUTE PROCEDURE search_iso_3166_3_update();
 
 CREATE TRIGGER search_iso_3166_3_delete BEFORE DELETE ON musicbrainz.iso_3166_3
     FOR EACH ROW EXECUTE PROCEDURE search_iso_3166_3_delete();
@@ -249,7 +303,9 @@ CREATE TRIGGER search_area_tag_insert AFTER INSERT ON musicbrainz.area_tag
     FOR EACH ROW EXECUTE PROCEDURE search_area_tag_insert();
 
 CREATE TRIGGER search_area_tag_update AFTER UPDATE OF area, count, tag ON musicbrainz.area_tag
-    FOR EACH ROW EXECUTE PROCEDURE search_area_tag_update();
+    FOR EACH ROW
+    WHEN ((OLD.area, OLD.count, OLD.tag) IS DISTINCT FROM (NEW.area, NEW.count, NEW.tag))
+    EXECUTE PROCEDURE search_area_tag_update();
 
 CREATE TRIGGER search_area_tag_delete BEFORE DELETE ON musicbrainz.area_tag
     FOR EACH ROW EXECUTE PROCEDURE search_area_tag_delete();
@@ -258,7 +314,9 @@ CREATE TRIGGER search_tag_insert AFTER INSERT ON musicbrainz.tag
     FOR EACH ROW EXECUTE PROCEDURE search_tag_insert();
 
 CREATE TRIGGER search_tag_update AFTER UPDATE OF id, name ON musicbrainz.tag
-    FOR EACH ROW EXECUTE PROCEDURE search_tag_update();
+    FOR EACH ROW
+    WHEN ((OLD.id, OLD.name) IS DISTINCT FROM (NEW.id, NEW.name))
+    EXECUTE PROCEDURE search_tag_update();
 
 CREATE TRIGGER search_tag_delete BEFORE DELETE ON musicbrainz.tag
     FOR EACH ROW EXECUTE PROCEDURE search_tag_delete();
@@ -267,7 +325,9 @@ CREATE TRIGGER search_area_type_insert AFTER INSERT ON musicbrainz.area_type
     FOR EACH ROW EXECUTE PROCEDURE search_area_type_insert();
 
 CREATE TRIGGER search_area_type_update AFTER UPDATE OF gid, id, name ON musicbrainz.area_type
-    FOR EACH ROW EXECUTE PROCEDURE search_area_type_update();
+    FOR EACH ROW
+    WHEN ((OLD.gid, OLD.id, OLD.name) IS DISTINCT FROM (NEW.gid, NEW.id, NEW.name))
+    EXECUTE PROCEDURE search_area_type_update();
 
 CREATE TRIGGER search_area_type_delete BEFORE DELETE ON musicbrainz.area_type
     FOR EACH ROW EXECUTE PROCEDURE search_area_type_delete();
@@ -276,7 +336,9 @@ CREATE TRIGGER search_artist_alias_insert AFTER INSERT ON musicbrainz.artist_ali
     FOR EACH ROW EXECUTE PROCEDURE search_artist_alias_insert();
 
 CREATE TRIGGER search_artist_alias_update AFTER UPDATE OF artist, begin_date_day, begin_date_month, begin_date_year, end_date_day, end_date_month, end_date_year, locale, name, primary_for_locale, sort_name, type ON musicbrainz.artist_alias
-    FOR EACH ROW EXECUTE PROCEDURE search_artist_alias_update();
+    FOR EACH ROW
+    WHEN ((OLD.artist, OLD.begin_date_day, OLD.begin_date_month, OLD.begin_date_year, OLD.end_date_day, OLD.end_date_month, OLD.end_date_year, OLD.locale, OLD.name, OLD.primary_for_locale, OLD.sort_name, OLD.type) IS DISTINCT FROM (NEW.artist, NEW.begin_date_day, NEW.begin_date_month, NEW.begin_date_year, NEW.end_date_day, NEW.end_date_month, NEW.end_date_year, NEW.locale, NEW.name, NEW.primary_for_locale, NEW.sort_name, NEW.type))
+    EXECUTE PROCEDURE search_artist_alias_update();
 
 CREATE TRIGGER search_artist_alias_delete BEFORE DELETE ON musicbrainz.artist_alias
     FOR EACH ROW EXECUTE PROCEDURE search_artist_alias_delete();
@@ -285,7 +347,9 @@ CREATE TRIGGER search_gender_insert AFTER INSERT ON musicbrainz.gender
     FOR EACH ROW EXECUTE PROCEDURE search_gender_insert();
 
 CREATE TRIGGER search_gender_update AFTER UPDATE OF gid, name ON musicbrainz.gender
-    FOR EACH ROW EXECUTE PROCEDURE search_gender_update();
+    FOR EACH ROW
+    WHEN ((OLD.gid, OLD.name) IS DISTINCT FROM (NEW.gid, NEW.name))
+    EXECUTE PROCEDURE search_gender_update();
 
 CREATE TRIGGER search_gender_delete BEFORE DELETE ON musicbrainz.gender
     FOR EACH ROW EXECUTE PROCEDURE search_gender_delete();
@@ -294,7 +358,9 @@ CREATE TRIGGER search_artist_ipi_insert AFTER INSERT ON musicbrainz.artist_ipi
     FOR EACH ROW EXECUTE PROCEDURE search_artist_ipi_insert();
 
 CREATE TRIGGER search_artist_ipi_update AFTER UPDATE OF artist, ipi ON musicbrainz.artist_ipi
-    FOR EACH ROW EXECUTE PROCEDURE search_artist_ipi_update();
+    FOR EACH ROW
+    WHEN ((OLD.artist, OLD.ipi) IS DISTINCT FROM (NEW.artist, NEW.ipi))
+    EXECUTE PROCEDURE search_artist_ipi_update();
 
 CREATE TRIGGER search_artist_ipi_delete BEFORE DELETE ON musicbrainz.artist_ipi
     FOR EACH ROW EXECUTE PROCEDURE search_artist_ipi_delete();
@@ -303,7 +369,9 @@ CREATE TRIGGER search_artist_isni_insert AFTER INSERT ON musicbrainz.artist_isni
     FOR EACH ROW EXECUTE PROCEDURE search_artist_isni_insert();
 
 CREATE TRIGGER search_artist_isni_update AFTER UPDATE OF artist, isni ON musicbrainz.artist_isni
-    FOR EACH ROW EXECUTE PROCEDURE search_artist_isni_update();
+    FOR EACH ROW
+    WHEN ((OLD.artist, OLD.isni) IS DISTINCT FROM (NEW.artist, NEW.isni))
+    EXECUTE PROCEDURE search_artist_isni_update();
 
 CREATE TRIGGER search_artist_isni_delete BEFORE DELETE ON musicbrainz.artist_isni
     FOR EACH ROW EXECUTE PROCEDURE search_artist_isni_delete();
@@ -312,7 +380,9 @@ CREATE TRIGGER search_artist_tag_insert AFTER INSERT ON musicbrainz.artist_tag
     FOR EACH ROW EXECUTE PROCEDURE search_artist_tag_insert();
 
 CREATE TRIGGER search_artist_tag_update AFTER UPDATE OF artist, count, tag ON musicbrainz.artist_tag
-    FOR EACH ROW EXECUTE PROCEDURE search_artist_tag_update();
+    FOR EACH ROW
+    WHEN ((OLD.artist, OLD.count, OLD.tag) IS DISTINCT FROM (NEW.artist, NEW.count, NEW.tag))
+    EXECUTE PROCEDURE search_artist_tag_update();
 
 CREATE TRIGGER search_artist_tag_delete BEFORE DELETE ON musicbrainz.artist_tag
     FOR EACH ROW EXECUTE PROCEDURE search_artist_tag_delete();
@@ -321,7 +391,9 @@ CREATE TRIGGER search_artist_type_insert AFTER INSERT ON musicbrainz.artist_type
     FOR EACH ROW EXECUTE PROCEDURE search_artist_type_insert();
 
 CREATE TRIGGER search_artist_type_update AFTER UPDATE OF gid, name ON musicbrainz.artist_type
-    FOR EACH ROW EXECUTE PROCEDURE search_artist_type_update();
+    FOR EACH ROW
+    WHEN ((OLD.gid, OLD.name) IS DISTINCT FROM (NEW.gid, NEW.name))
+    EXECUTE PROCEDURE search_artist_type_update();
 
 CREATE TRIGGER search_artist_type_delete BEFORE DELETE ON musicbrainz.artist_type
     FOR EACH ROW EXECUTE PROCEDURE search_artist_type_delete();
@@ -330,7 +402,9 @@ CREATE TRIGGER search_release_raw_insert AFTER INSERT ON musicbrainz.release_raw
     FOR EACH ROW EXECUTE PROCEDURE search_release_raw_insert();
 
 CREATE TRIGGER search_release_raw_update AFTER UPDATE OF added, artist, barcode, comment, id, title ON musicbrainz.release_raw
-    FOR EACH ROW EXECUTE PROCEDURE search_release_raw_update();
+    FOR EACH ROW
+    WHEN ((OLD.added, OLD.artist, OLD.barcode, OLD.comment, OLD.id, OLD.title) IS DISTINCT FROM (NEW.added, NEW.artist, NEW.barcode, NEW.comment, NEW.id, NEW.title))
+    EXECUTE PROCEDURE search_release_raw_update();
 
 CREATE TRIGGER search_release_raw_delete BEFORE DELETE ON musicbrainz.release_raw
     FOR EACH ROW EXECUTE PROCEDURE search_release_raw_delete();
@@ -339,7 +413,9 @@ CREATE TRIGGER search_cdtoc_raw_insert AFTER INSERT ON musicbrainz.cdtoc_raw
     FOR EACH ROW EXECUTE PROCEDURE search_cdtoc_raw_insert();
 
 CREATE TRIGGER search_cdtoc_raw_update AFTER UPDATE OF discid, release, track_count ON musicbrainz.cdtoc_raw
-    FOR EACH ROW EXECUTE PROCEDURE search_cdtoc_raw_update();
+    FOR EACH ROW
+    WHEN ((OLD.discid, OLD.release, OLD.track_count) IS DISTINCT FROM (NEW.discid, NEW.release, NEW.track_count))
+    EXECUTE PROCEDURE search_cdtoc_raw_update();
 
 CREATE TRIGGER search_cdtoc_raw_delete BEFORE DELETE ON musicbrainz.cdtoc_raw
     FOR EACH ROW EXECUTE PROCEDURE search_cdtoc_raw_delete();
@@ -348,7 +424,9 @@ CREATE TRIGGER search_editor_insert AFTER INSERT ON musicbrainz.editor
     FOR EACH ROW EXECUTE PROCEDURE search_editor_insert();
 
 CREATE TRIGGER search_editor_update AFTER UPDATE OF area, bio, gender, id, name ON musicbrainz.editor
-    FOR EACH ROW EXECUTE PROCEDURE search_editor_update();
+    FOR EACH ROW
+    WHEN ((OLD.area, OLD.bio, OLD.gender, OLD.id, OLD.name) IS DISTINCT FROM (NEW.area, NEW.bio, NEW.gender, NEW.id, NEW.name))
+    EXECUTE PROCEDURE search_editor_update();
 
 CREATE TRIGGER search_editor_delete BEFORE DELETE ON musicbrainz.editor
     FOR EACH ROW EXECUTE PROCEDURE search_editor_delete();
@@ -357,7 +435,9 @@ CREATE TRIGGER search_event_alias_insert AFTER INSERT ON musicbrainz.event_alias
     FOR EACH ROW EXECUTE PROCEDURE search_event_alias_insert();
 
 CREATE TRIGGER search_event_alias_update AFTER UPDATE OF begin_date_day, begin_date_month, begin_date_year, end_date_day, end_date_month, end_date_year, event, locale, name, primary_for_locale, sort_name, type ON musicbrainz.event_alias
-    FOR EACH ROW EXECUTE PROCEDURE search_event_alias_update();
+    FOR EACH ROW
+    WHEN ((OLD.begin_date_day, OLD.begin_date_month, OLD.begin_date_year, OLD.end_date_day, OLD.end_date_month, OLD.end_date_year, OLD.event, OLD.locale, OLD.name, OLD.primary_for_locale, OLD.sort_name, OLD.type) IS DISTINCT FROM (NEW.begin_date_day, NEW.begin_date_month, NEW.begin_date_year, NEW.end_date_day, NEW.end_date_month, NEW.end_date_year, NEW.event, NEW.locale, NEW.name, NEW.primary_for_locale, NEW.sort_name, NEW.type))
+    EXECUTE PROCEDURE search_event_alias_update();
 
 CREATE TRIGGER search_event_alias_delete BEFORE DELETE ON musicbrainz.event_alias
     FOR EACH ROW EXECUTE PROCEDURE search_event_alias_delete();
@@ -366,7 +446,9 @@ CREATE TRIGGER search_l_area_event_insert AFTER INSERT ON musicbrainz.l_area_eve
     FOR EACH ROW EXECUTE PROCEDURE search_l_area_event_insert();
 
 CREATE TRIGGER search_l_area_event_update AFTER UPDATE OF entity0, entity1, link ON musicbrainz.l_area_event
-    FOR EACH ROW EXECUTE PROCEDURE search_l_area_event_update();
+    FOR EACH ROW
+    WHEN ((OLD.entity0, OLD.entity1, OLD.link) IS DISTINCT FROM (NEW.entity0, NEW.entity1, NEW.link))
+    EXECUTE PROCEDURE search_l_area_event_update();
 
 CREATE TRIGGER search_l_area_event_delete BEFORE DELETE ON musicbrainz.l_area_event
     FOR EACH ROW EXECUTE PROCEDURE search_l_area_event_delete();
@@ -375,7 +457,9 @@ CREATE TRIGGER search_l_artist_event_insert AFTER INSERT ON musicbrainz.l_artist
     FOR EACH ROW EXECUTE PROCEDURE search_l_artist_event_insert();
 
 CREATE TRIGGER search_l_artist_event_update AFTER UPDATE OF entity0, entity1, link ON musicbrainz.l_artist_event
-    FOR EACH ROW EXECUTE PROCEDURE search_l_artist_event_update();
+    FOR EACH ROW
+    WHEN ((OLD.entity0, OLD.entity1, OLD.link) IS DISTINCT FROM (NEW.entity0, NEW.entity1, NEW.link))
+    EXECUTE PROCEDURE search_l_artist_event_update();
 
 CREATE TRIGGER search_l_artist_event_delete BEFORE DELETE ON musicbrainz.l_artist_event
     FOR EACH ROW EXECUTE PROCEDURE search_l_artist_event_delete();
@@ -384,7 +468,9 @@ CREATE TRIGGER search_l_event_place_insert AFTER INSERT ON musicbrainz.l_event_p
     FOR EACH ROW EXECUTE PROCEDURE search_l_event_place_insert();
 
 CREATE TRIGGER search_l_event_place_update AFTER UPDATE OF entity0, entity1, link ON musicbrainz.l_event_place
-    FOR EACH ROW EXECUTE PROCEDURE search_l_event_place_update();
+    FOR EACH ROW
+    WHEN ((OLD.entity0, OLD.entity1, OLD.link) IS DISTINCT FROM (NEW.entity0, NEW.entity1, NEW.link))
+    EXECUTE PROCEDURE search_l_event_place_update();
 
 CREATE TRIGGER search_l_event_place_delete BEFORE DELETE ON musicbrainz.l_event_place
     FOR EACH ROW EXECUTE PROCEDURE search_l_event_place_delete();
@@ -393,7 +479,9 @@ CREATE TRIGGER search_event_tag_insert AFTER INSERT ON musicbrainz.event_tag
     FOR EACH ROW EXECUTE PROCEDURE search_event_tag_insert();
 
 CREATE TRIGGER search_event_tag_update AFTER UPDATE OF count, event, tag ON musicbrainz.event_tag
-    FOR EACH ROW EXECUTE PROCEDURE search_event_tag_update();
+    FOR EACH ROW
+    WHEN ((OLD.count, OLD.event, OLD.tag) IS DISTINCT FROM (NEW.count, NEW.event, NEW.tag))
+    EXECUTE PROCEDURE search_event_tag_update();
 
 CREATE TRIGGER search_event_tag_delete BEFORE DELETE ON musicbrainz.event_tag
     FOR EACH ROW EXECUTE PROCEDURE search_event_tag_delete();
@@ -402,7 +490,9 @@ CREATE TRIGGER search_event_type_insert AFTER INSERT ON musicbrainz.event_type
     FOR EACH ROW EXECUTE PROCEDURE search_event_type_insert();
 
 CREATE TRIGGER search_event_type_update AFTER UPDATE OF gid, name ON musicbrainz.event_type
-    FOR EACH ROW EXECUTE PROCEDURE search_event_type_update();
+    FOR EACH ROW
+    WHEN ((OLD.gid, OLD.name) IS DISTINCT FROM (NEW.gid, NEW.name))
+    EXECUTE PROCEDURE search_event_type_update();
 
 CREATE TRIGGER search_event_type_delete BEFORE DELETE ON musicbrainz.event_type
     FOR EACH ROW EXECUTE PROCEDURE search_event_type_delete();
@@ -411,7 +501,9 @@ CREATE TRIGGER search_instrument_alias_insert AFTER INSERT ON musicbrainz.instru
     FOR EACH ROW EXECUTE PROCEDURE search_instrument_alias_insert();
 
 CREATE TRIGGER search_instrument_alias_update AFTER UPDATE OF begin_date_day, begin_date_month, begin_date_year, end_date_day, end_date_month, end_date_year, instrument, locale, name, primary_for_locale, sort_name, type ON musicbrainz.instrument_alias
-    FOR EACH ROW EXECUTE PROCEDURE search_instrument_alias_update();
+    FOR EACH ROW
+    WHEN ((OLD.begin_date_day, OLD.begin_date_month, OLD.begin_date_year, OLD.end_date_day, OLD.end_date_month, OLD.end_date_year, OLD.instrument, OLD.locale, OLD.name, OLD.primary_for_locale, OLD.sort_name, OLD.type) IS DISTINCT FROM (NEW.begin_date_day, NEW.begin_date_month, NEW.begin_date_year, NEW.end_date_day, NEW.end_date_month, NEW.end_date_year, NEW.instrument, NEW.locale, NEW.name, NEW.primary_for_locale, NEW.sort_name, NEW.type))
+    EXECUTE PROCEDURE search_instrument_alias_update();
 
 CREATE TRIGGER search_instrument_alias_delete BEFORE DELETE ON musicbrainz.instrument_alias
     FOR EACH ROW EXECUTE PROCEDURE search_instrument_alias_delete();
@@ -420,7 +512,9 @@ CREATE TRIGGER search_instrument_tag_insert AFTER INSERT ON musicbrainz.instrume
     FOR EACH ROW EXECUTE PROCEDURE search_instrument_tag_insert();
 
 CREATE TRIGGER search_instrument_tag_update AFTER UPDATE OF count, instrument, tag ON musicbrainz.instrument_tag
-    FOR EACH ROW EXECUTE PROCEDURE search_instrument_tag_update();
+    FOR EACH ROW
+    WHEN ((OLD.count, OLD.instrument, OLD.tag) IS DISTINCT FROM (NEW.count, NEW.instrument, NEW.tag))
+    EXECUTE PROCEDURE search_instrument_tag_update();
 
 CREATE TRIGGER search_instrument_tag_delete BEFORE DELETE ON musicbrainz.instrument_tag
     FOR EACH ROW EXECUTE PROCEDURE search_instrument_tag_delete();
@@ -429,7 +523,9 @@ CREATE TRIGGER search_instrument_type_insert AFTER INSERT ON musicbrainz.instrum
     FOR EACH ROW EXECUTE PROCEDURE search_instrument_type_insert();
 
 CREATE TRIGGER search_instrument_type_update AFTER UPDATE OF gid, name ON musicbrainz.instrument_type
-    FOR EACH ROW EXECUTE PROCEDURE search_instrument_type_update();
+    FOR EACH ROW
+    WHEN ((OLD.gid, OLD.name) IS DISTINCT FROM (NEW.gid, NEW.name))
+    EXECUTE PROCEDURE search_instrument_type_update();
 
 CREATE TRIGGER search_instrument_type_delete BEFORE DELETE ON musicbrainz.instrument_type
     FOR EACH ROW EXECUTE PROCEDURE search_instrument_type_delete();
@@ -438,7 +534,9 @@ CREATE TRIGGER search_label_alias_insert AFTER INSERT ON musicbrainz.label_alias
     FOR EACH ROW EXECUTE PROCEDURE search_label_alias_insert();
 
 CREATE TRIGGER search_label_alias_update AFTER UPDATE OF begin_date_day, begin_date_month, begin_date_year, end_date_day, end_date_month, end_date_year, label, locale, name, primary_for_locale, sort_name, type ON musicbrainz.label_alias
-    FOR EACH ROW EXECUTE PROCEDURE search_label_alias_update();
+    FOR EACH ROW
+    WHEN ((OLD.begin_date_day, OLD.begin_date_month, OLD.begin_date_year, OLD.end_date_day, OLD.end_date_month, OLD.end_date_year, OLD.label, OLD.locale, OLD.name, OLD.primary_for_locale, OLD.sort_name, OLD.type) IS DISTINCT FROM (NEW.begin_date_day, NEW.begin_date_month, NEW.begin_date_year, NEW.end_date_day, NEW.end_date_month, NEW.end_date_year, NEW.label, NEW.locale, NEW.name, NEW.primary_for_locale, NEW.sort_name, NEW.type))
+    EXECUTE PROCEDURE search_label_alias_update();
 
 CREATE TRIGGER search_label_alias_delete BEFORE DELETE ON musicbrainz.label_alias
     FOR EACH ROW EXECUTE PROCEDURE search_label_alias_delete();
@@ -447,7 +545,9 @@ CREATE TRIGGER search_label_ipi_insert AFTER INSERT ON musicbrainz.label_ipi
     FOR EACH ROW EXECUTE PROCEDURE search_label_ipi_insert();
 
 CREATE TRIGGER search_label_ipi_update AFTER UPDATE OF ipi, label ON musicbrainz.label_ipi
-    FOR EACH ROW EXECUTE PROCEDURE search_label_ipi_update();
+    FOR EACH ROW
+    WHEN ((OLD.ipi, OLD.label) IS DISTINCT FROM (NEW.ipi, NEW.label))
+    EXECUTE PROCEDURE search_label_ipi_update();
 
 CREATE TRIGGER search_label_ipi_delete BEFORE DELETE ON musicbrainz.label_ipi
     FOR EACH ROW EXECUTE PROCEDURE search_label_ipi_delete();
@@ -456,7 +556,9 @@ CREATE TRIGGER search_label_isni_insert AFTER INSERT ON musicbrainz.label_isni
     FOR EACH ROW EXECUTE PROCEDURE search_label_isni_insert();
 
 CREATE TRIGGER search_label_isni_update AFTER UPDATE OF isni, label ON musicbrainz.label_isni
-    FOR EACH ROW EXECUTE PROCEDURE search_label_isni_update();
+    FOR EACH ROW
+    WHEN ((OLD.isni, OLD.label) IS DISTINCT FROM (NEW.isni, NEW.label))
+    EXECUTE PROCEDURE search_label_isni_update();
 
 CREATE TRIGGER search_label_isni_delete BEFORE DELETE ON musicbrainz.label_isni
     FOR EACH ROW EXECUTE PROCEDURE search_label_isni_delete();
@@ -465,7 +567,9 @@ CREATE TRIGGER search_label_tag_insert AFTER INSERT ON musicbrainz.label_tag
     FOR EACH ROW EXECUTE PROCEDURE search_label_tag_insert();
 
 CREATE TRIGGER search_label_tag_update AFTER UPDATE OF count, label, tag ON musicbrainz.label_tag
-    FOR EACH ROW EXECUTE PROCEDURE search_label_tag_update();
+    FOR EACH ROW
+    WHEN ((OLD.count, OLD.label, OLD.tag) IS DISTINCT FROM (NEW.count, NEW.label, NEW.tag))
+    EXECUTE PROCEDURE search_label_tag_update();
 
 CREATE TRIGGER search_label_tag_delete BEFORE DELETE ON musicbrainz.label_tag
     FOR EACH ROW EXECUTE PROCEDURE search_label_tag_delete();
@@ -474,7 +578,9 @@ CREATE TRIGGER search_label_type_insert AFTER INSERT ON musicbrainz.label_type
     FOR EACH ROW EXECUTE PROCEDURE search_label_type_insert();
 
 CREATE TRIGGER search_label_type_update AFTER UPDATE OF gid, name ON musicbrainz.label_type
-    FOR EACH ROW EXECUTE PROCEDURE search_label_type_update();
+    FOR EACH ROW
+    WHEN ((OLD.gid, OLD.name) IS DISTINCT FROM (NEW.gid, NEW.name))
+    EXECUTE PROCEDURE search_label_type_update();
 
 CREATE TRIGGER search_label_type_delete BEFORE DELETE ON musicbrainz.label_type
     FOR EACH ROW EXECUTE PROCEDURE search_label_type_delete();
@@ -483,7 +589,9 @@ CREATE TRIGGER search_place_alias_insert AFTER INSERT ON musicbrainz.place_alias
     FOR EACH ROW EXECUTE PROCEDURE search_place_alias_insert();
 
 CREATE TRIGGER search_place_alias_update AFTER UPDATE OF begin_date_day, begin_date_month, begin_date_year, end_date_day, end_date_month, end_date_year, locale, name, place, primary_for_locale, sort_name, type ON musicbrainz.place_alias
-    FOR EACH ROW EXECUTE PROCEDURE search_place_alias_update();
+    FOR EACH ROW
+    WHEN ((OLD.begin_date_day, OLD.begin_date_month, OLD.begin_date_year, OLD.end_date_day, OLD.end_date_month, OLD.end_date_year, OLD.locale, OLD.name, OLD.place, OLD.primary_for_locale, OLD.sort_name, OLD.type) IS DISTINCT FROM (NEW.begin_date_day, NEW.begin_date_month, NEW.begin_date_year, NEW.end_date_day, NEW.end_date_month, NEW.end_date_year, NEW.locale, NEW.name, NEW.place, NEW.primary_for_locale, NEW.sort_name, NEW.type))
+    EXECUTE PROCEDURE search_place_alias_update();
 
 CREATE TRIGGER search_place_alias_delete BEFORE DELETE ON musicbrainz.place_alias
     FOR EACH ROW EXECUTE PROCEDURE search_place_alias_delete();
@@ -492,7 +600,9 @@ CREATE TRIGGER search_place_type_insert AFTER INSERT ON musicbrainz.place_type
     FOR EACH ROW EXECUTE PROCEDURE search_place_type_insert();
 
 CREATE TRIGGER search_place_type_update AFTER UPDATE OF gid, name ON musicbrainz.place_type
-    FOR EACH ROW EXECUTE PROCEDURE search_place_type_update();
+    FOR EACH ROW
+    WHEN ((OLD.gid, OLD.name) IS DISTINCT FROM (NEW.gid, NEW.name))
+    EXECUTE PROCEDURE search_place_type_update();
 
 CREATE TRIGGER search_place_type_delete BEFORE DELETE ON musicbrainz.place_type
     FOR EACH ROW EXECUTE PROCEDURE search_place_type_delete();
@@ -501,7 +611,9 @@ CREATE TRIGGER search_recording_alias_insert AFTER INSERT ON musicbrainz.recordi
     FOR EACH ROW EXECUTE PROCEDURE search_recording_alias_insert();
 
 CREATE TRIGGER search_recording_alias_update AFTER UPDATE OF name, recording, type ON musicbrainz.recording_alias
-    FOR EACH ROW EXECUTE PROCEDURE search_recording_alias_update();
+    FOR EACH ROW
+    WHEN ((OLD.name, OLD.recording, OLD.type) IS DISTINCT FROM (NEW.name, NEW.recording, NEW.type))
+    EXECUTE PROCEDURE search_recording_alias_update();
 
 CREATE TRIGGER search_recording_alias_delete BEFORE DELETE ON musicbrainz.recording_alias
     FOR EACH ROW EXECUTE PROCEDURE search_recording_alias_delete();
@@ -510,7 +622,9 @@ CREATE TRIGGER search_artist_credit_insert AFTER INSERT ON musicbrainz.artist_cr
     FOR EACH ROW EXECUTE PROCEDURE search_artist_credit_insert();
 
 CREATE TRIGGER search_artist_credit_update AFTER UPDATE OF name ON musicbrainz.artist_credit
-    FOR EACH ROW EXECUTE PROCEDURE search_artist_credit_update();
+    FOR EACH ROW
+    WHEN ((OLD.name) IS DISTINCT FROM (NEW.name))
+    EXECUTE PROCEDURE search_artist_credit_update();
 
 CREATE TRIGGER search_artist_credit_delete BEFORE DELETE ON musicbrainz.artist_credit
     FOR EACH ROW EXECUTE PROCEDURE search_artist_credit_delete();
@@ -519,7 +633,9 @@ CREATE TRIGGER search_artist_credit_name_insert AFTER INSERT ON musicbrainz.arti
     FOR EACH ROW EXECUTE PROCEDURE search_artist_credit_name_insert();
 
 CREATE TRIGGER search_artist_credit_name_update AFTER UPDATE OF artist, artist_credit, join_phrase, name ON musicbrainz.artist_credit_name
-    FOR EACH ROW EXECUTE PROCEDURE search_artist_credit_name_update();
+    FOR EACH ROW
+    WHEN ((OLD.artist, OLD.artist_credit, OLD.join_phrase, OLD.name) IS DISTINCT FROM (NEW.artist, NEW.artist_credit, NEW.join_phrase, NEW.name))
+    EXECUTE PROCEDURE search_artist_credit_name_update();
 
 CREATE TRIGGER search_artist_credit_name_delete BEFORE DELETE ON musicbrainz.artist_credit_name
     FOR EACH ROW EXECUTE PROCEDURE search_artist_credit_name_delete();
@@ -528,7 +644,9 @@ CREATE TRIGGER search_track_insert AFTER INSERT ON musicbrainz.track
     FOR EACH ROW EXECUTE PROCEDURE search_track_insert();
 
 CREATE TRIGGER search_track_update AFTER UPDATE OF artist_credit, gid, length, medium, name, number, position, recording ON musicbrainz.track
-    FOR EACH ROW EXECUTE PROCEDURE search_track_update();
+    FOR EACH ROW
+    WHEN ((OLD.artist_credit, OLD.gid, OLD.length, OLD.medium, OLD.name, OLD.number, OLD.position, OLD.recording) IS DISTINCT FROM (NEW.artist_credit, NEW.gid, NEW.length, NEW.medium, NEW.name, NEW.number, NEW.position, NEW.recording))
+    EXECUTE PROCEDURE search_track_update();
 
 CREATE TRIGGER search_track_delete BEFORE DELETE ON musicbrainz.track
     FOR EACH ROW EXECUTE PROCEDURE search_track_delete();
@@ -537,7 +655,9 @@ CREATE TRIGGER search_medium_insert AFTER INSERT ON musicbrainz.medium
     FOR EACH ROW EXECUTE PROCEDURE search_medium_insert();
 
 CREATE TRIGGER search_medium_update AFTER UPDATE OF format, position, release, track_count ON musicbrainz.medium
-    FOR EACH ROW EXECUTE PROCEDURE search_medium_update();
+    FOR EACH ROW
+    WHEN ((OLD.format, OLD.position, OLD.release, OLD.track_count) IS DISTINCT FROM (NEW.format, NEW.position, NEW.release, NEW.track_count))
+    EXECUTE PROCEDURE search_medium_update();
 
 CREATE TRIGGER search_medium_delete BEFORE DELETE ON musicbrainz.medium
     FOR EACH ROW EXECUTE PROCEDURE search_medium_delete();
@@ -546,7 +666,9 @@ CREATE TRIGGER search_release_country_insert AFTER INSERT ON musicbrainz.release
     FOR EACH ROW EXECUTE PROCEDURE search_release_country_insert();
 
 CREATE TRIGGER search_release_country_update AFTER UPDATE OF country, date_day, date_month, date_year, release ON musicbrainz.release_country
-    FOR EACH ROW EXECUTE PROCEDURE search_release_country_update();
+    FOR EACH ROW
+    WHEN ((OLD.country, OLD.date_day, OLD.date_month, OLD.date_year, OLD.release) IS DISTINCT FROM (NEW.country, NEW.date_day, NEW.date_month, NEW.date_year, NEW.release))
+    EXECUTE PROCEDURE search_release_country_update();
 
 CREATE TRIGGER search_release_country_delete BEFORE DELETE ON musicbrainz.release_country
     FOR EACH ROW EXECUTE PROCEDURE search_release_country_delete();
@@ -555,7 +677,9 @@ CREATE TRIGGER search_country_area_insert AFTER INSERT ON musicbrainz.country_ar
     FOR EACH ROW EXECUTE PROCEDURE search_country_area_insert();
 
 CREATE TRIGGER search_country_area_update AFTER UPDATE OF area ON musicbrainz.country_area
-    FOR EACH ROW EXECUTE PROCEDURE search_country_area_update();
+    FOR EACH ROW
+    WHEN ((OLD.area) IS DISTINCT FROM (NEW.area))
+    EXECUTE PROCEDURE search_country_area_update();
 
 CREATE TRIGGER search_country_area_delete BEFORE DELETE ON musicbrainz.country_area
     FOR EACH ROW EXECUTE PROCEDURE search_country_area_delete();
@@ -564,7 +688,9 @@ CREATE TRIGGER search_recording_first_release_date_insert AFTER INSERT ON musicb
     FOR EACH ROW EXECUTE PROCEDURE search_recording_first_release_date_insert();
 
 CREATE TRIGGER search_recording_first_release_date_update AFTER UPDATE OF day, month, recording, year ON musicbrainz.recording_first_release_date
-    FOR EACH ROW EXECUTE PROCEDURE search_recording_first_release_date_update();
+    FOR EACH ROW
+    WHEN ((OLD.day, OLD.month, OLD.recording, OLD.year) IS DISTINCT FROM (NEW.day, NEW.month, NEW.recording, NEW.year))
+    EXECUTE PROCEDURE search_recording_first_release_date_update();
 
 CREATE TRIGGER search_recording_first_release_date_delete BEFORE DELETE ON musicbrainz.recording_first_release_date
     FOR EACH ROW EXECUTE PROCEDURE search_recording_first_release_date_delete();
@@ -573,7 +699,9 @@ CREATE TRIGGER search_medium_format_insert AFTER INSERT ON musicbrainz.medium_fo
     FOR EACH ROW EXECUTE PROCEDURE search_medium_format_insert();
 
 CREATE TRIGGER search_medium_format_update AFTER UPDATE OF name ON musicbrainz.medium_format
-    FOR EACH ROW EXECUTE PROCEDURE search_medium_format_update();
+    FOR EACH ROW
+    WHEN ((OLD.name) IS DISTINCT FROM (NEW.name))
+    EXECUTE PROCEDURE search_medium_format_update();
 
 CREATE TRIGGER search_medium_format_delete BEFORE DELETE ON musicbrainz.medium_format
     FOR EACH ROW EXECUTE PROCEDURE search_medium_format_delete();
@@ -582,7 +710,9 @@ CREATE TRIGGER search_isrc_insert AFTER INSERT ON musicbrainz.isrc
     FOR EACH ROW EXECUTE PROCEDURE search_isrc_insert();
 
 CREATE TRIGGER search_isrc_update AFTER UPDATE OF isrc, recording ON musicbrainz.isrc
-    FOR EACH ROW EXECUTE PROCEDURE search_isrc_update();
+    FOR EACH ROW
+    WHEN ((OLD.isrc, OLD.recording) IS DISTINCT FROM (NEW.isrc, NEW.recording))
+    EXECUTE PROCEDURE search_isrc_update();
 
 CREATE TRIGGER search_isrc_delete BEFORE DELETE ON musicbrainz.isrc
     FOR EACH ROW EXECUTE PROCEDURE search_isrc_delete();
@@ -591,7 +721,9 @@ CREATE TRIGGER search_release_group_primary_type_insert AFTER INSERT ON musicbra
     FOR EACH ROW EXECUTE PROCEDURE search_release_group_primary_type_insert();
 
 CREATE TRIGGER search_release_group_primary_type_update AFTER UPDATE OF gid, name ON musicbrainz.release_group_primary_type
-    FOR EACH ROW EXECUTE PROCEDURE search_release_group_primary_type_update();
+    FOR EACH ROW
+    WHEN ((OLD.gid, OLD.name) IS DISTINCT FROM (NEW.gid, NEW.name))
+    EXECUTE PROCEDURE search_release_group_primary_type_update();
 
 CREATE TRIGGER search_release_group_primary_type_delete BEFORE DELETE ON musicbrainz.release_group_primary_type
     FOR EACH ROW EXECUTE PROCEDURE search_release_group_primary_type_delete();
@@ -600,7 +732,9 @@ CREATE TRIGGER search_release_group_secondary_type_join_insert AFTER INSERT ON m
     FOR EACH ROW EXECUTE PROCEDURE search_release_group_secondary_type_join_insert();
 
 CREATE TRIGGER search_release_group_secondary_type_join_update AFTER UPDATE OF release_group, secondary_type ON musicbrainz.release_group_secondary_type_join
-    FOR EACH ROW EXECUTE PROCEDURE search_release_group_secondary_type_join_update();
+    FOR EACH ROW
+    WHEN ((OLD.release_group, OLD.secondary_type) IS DISTINCT FROM (NEW.release_group, NEW.secondary_type))
+    EXECUTE PROCEDURE search_release_group_secondary_type_join_update();
 
 CREATE TRIGGER search_release_group_secondary_type_join_delete BEFORE DELETE ON musicbrainz.release_group_secondary_type_join
     FOR EACH ROW EXECUTE PROCEDURE search_release_group_secondary_type_join_delete();
@@ -609,7 +743,9 @@ CREATE TRIGGER search_release_group_secondary_type_insert AFTER INSERT ON musicb
     FOR EACH ROW EXECUTE PROCEDURE search_release_group_secondary_type_insert();
 
 CREATE TRIGGER search_release_group_secondary_type_update AFTER UPDATE OF gid, name ON musicbrainz.release_group_secondary_type
-    FOR EACH ROW EXECUTE PROCEDURE search_release_group_secondary_type_update();
+    FOR EACH ROW
+    WHEN ((OLD.gid, OLD.name) IS DISTINCT FROM (NEW.gid, NEW.name))
+    EXECUTE PROCEDURE search_release_group_secondary_type_update();
 
 CREATE TRIGGER search_release_group_secondary_type_delete BEFORE DELETE ON musicbrainz.release_group_secondary_type
     FOR EACH ROW EXECUTE PROCEDURE search_release_group_secondary_type_delete();
@@ -618,7 +754,9 @@ CREATE TRIGGER search_release_status_insert AFTER INSERT ON musicbrainz.release_
     FOR EACH ROW EXECUTE PROCEDURE search_release_status_insert();
 
 CREATE TRIGGER search_release_status_update AFTER UPDATE OF gid, name ON musicbrainz.release_status
-    FOR EACH ROW EXECUTE PROCEDURE search_release_status_update();
+    FOR EACH ROW
+    WHEN ((OLD.gid, OLD.name) IS DISTINCT FROM (NEW.gid, NEW.name))
+    EXECUTE PROCEDURE search_release_status_update();
 
 CREATE TRIGGER search_release_status_delete BEFORE DELETE ON musicbrainz.release_status
     FOR EACH ROW EXECUTE PROCEDURE search_release_status_delete();
@@ -627,7 +765,9 @@ CREATE TRIGGER search_recording_tag_insert AFTER INSERT ON musicbrainz.recording
     FOR EACH ROW EXECUTE PROCEDURE search_recording_tag_insert();
 
 CREATE TRIGGER search_recording_tag_update AFTER UPDATE OF count, recording, tag ON musicbrainz.recording_tag
-    FOR EACH ROW EXECUTE PROCEDURE search_recording_tag_update();
+    FOR EACH ROW
+    WHEN ((OLD.count, OLD.recording, OLD.tag) IS DISTINCT FROM (NEW.count, NEW.recording, NEW.tag))
+    EXECUTE PROCEDURE search_recording_tag_update();
 
 CREATE TRIGGER search_recording_tag_delete BEFORE DELETE ON musicbrainz.recording_tag
     FOR EACH ROW EXECUTE PROCEDURE search_recording_tag_delete();
@@ -636,7 +776,9 @@ CREATE TRIGGER search_release_alias_insert AFTER INSERT ON musicbrainz.release_a
     FOR EACH ROW EXECUTE PROCEDURE search_release_alias_insert();
 
 CREATE TRIGGER search_release_alias_update AFTER UPDATE OF name, release, type ON musicbrainz.release_alias
-    FOR EACH ROW EXECUTE PROCEDURE search_release_alias_update();
+    FOR EACH ROW
+    WHEN ((OLD.name, OLD.release, OLD.type) IS DISTINCT FROM (NEW.name, NEW.release, NEW.type))
+    EXECUTE PROCEDURE search_release_alias_update();
 
 CREATE TRIGGER search_release_alias_delete BEFORE DELETE ON musicbrainz.release_alias
     FOR EACH ROW EXECUTE PROCEDURE search_release_alias_delete();
@@ -645,7 +787,9 @@ CREATE TRIGGER search_release_meta_insert AFTER INSERT ON musicbrainz.release_me
     FOR EACH ROW EXECUTE PROCEDURE search_release_meta_insert();
 
 CREATE TRIGGER search_release_meta_update AFTER UPDATE OF amazon_asin, id ON musicbrainz.release_meta
-    FOR EACH ROW EXECUTE PROCEDURE search_release_meta_update();
+    FOR EACH ROW
+    WHEN ((OLD.amazon_asin, OLD.id) IS DISTINCT FROM (NEW.amazon_asin, NEW.id))
+    EXECUTE PROCEDURE search_release_meta_update();
 
 CREATE TRIGGER search_release_meta_delete BEFORE DELETE ON musicbrainz.release_meta
     FOR EACH ROW EXECUTE PROCEDURE search_release_meta_delete();
@@ -654,7 +798,9 @@ CREATE TRIGGER search_release_label_insert AFTER INSERT ON musicbrainz.release_l
     FOR EACH ROW EXECUTE PROCEDURE search_release_label_insert();
 
 CREATE TRIGGER search_release_label_update AFTER UPDATE OF catalog_number, label, release ON musicbrainz.release_label
-    FOR EACH ROW EXECUTE PROCEDURE search_release_label_update();
+    FOR EACH ROW
+    WHEN ((OLD.catalog_number, OLD.label, OLD.release) IS DISTINCT FROM (NEW.catalog_number, NEW.label, NEW.release))
+    EXECUTE PROCEDURE search_release_label_update();
 
 CREATE TRIGGER search_release_label_delete BEFORE DELETE ON musicbrainz.release_label
     FOR EACH ROW EXECUTE PROCEDURE search_release_label_delete();
@@ -663,7 +809,9 @@ CREATE TRIGGER search_language_insert AFTER INSERT ON musicbrainz.language
     FOR EACH ROW EXECUTE PROCEDURE search_language_insert();
 
 CREATE TRIGGER search_language_update AFTER UPDATE OF iso_code_3 ON musicbrainz.language
-    FOR EACH ROW EXECUTE PROCEDURE search_language_update();
+    FOR EACH ROW
+    WHEN ((OLD.iso_code_3) IS DISTINCT FROM (NEW.iso_code_3))
+    EXECUTE PROCEDURE search_language_update();
 
 CREATE TRIGGER search_language_delete BEFORE DELETE ON musicbrainz.language
     FOR EACH ROW EXECUTE PROCEDURE search_language_delete();
@@ -672,7 +820,9 @@ CREATE TRIGGER search_release_packaging_insert AFTER INSERT ON musicbrainz.relea
     FOR EACH ROW EXECUTE PROCEDURE search_release_packaging_insert();
 
 CREATE TRIGGER search_release_packaging_update AFTER UPDATE OF name ON musicbrainz.release_packaging
-    FOR EACH ROW EXECUTE PROCEDURE search_release_packaging_update();
+    FOR EACH ROW
+    WHEN ((OLD.name) IS DISTINCT FROM (NEW.name))
+    EXECUTE PROCEDURE search_release_packaging_update();
 
 CREATE TRIGGER search_release_packaging_delete BEFORE DELETE ON musicbrainz.release_packaging
     FOR EACH ROW EXECUTE PROCEDURE search_release_packaging_delete();
@@ -681,7 +831,9 @@ CREATE TRIGGER search_script_insert AFTER INSERT ON musicbrainz.script
     FOR EACH ROW EXECUTE PROCEDURE search_script_insert();
 
 CREATE TRIGGER search_script_update AFTER UPDATE OF iso_code ON musicbrainz.script
-    FOR EACH ROW EXECUTE PROCEDURE search_script_update();
+    FOR EACH ROW
+    WHEN ((OLD.iso_code) IS DISTINCT FROM (NEW.iso_code))
+    EXECUTE PROCEDURE search_script_update();
 
 CREATE TRIGGER search_script_delete BEFORE DELETE ON musicbrainz.script
     FOR EACH ROW EXECUTE PROCEDURE search_script_delete();
@@ -690,7 +842,9 @@ CREATE TRIGGER search_release_tag_insert AFTER INSERT ON musicbrainz.release_tag
     FOR EACH ROW EXECUTE PROCEDURE search_release_tag_insert();
 
 CREATE TRIGGER search_release_tag_update AFTER UPDATE OF count, release, tag ON musicbrainz.release_tag
-    FOR EACH ROW EXECUTE PROCEDURE search_release_tag_update();
+    FOR EACH ROW
+    WHEN ((OLD.count, OLD.release, OLD.tag) IS DISTINCT FROM (NEW.count, NEW.release, NEW.tag))
+    EXECUTE PROCEDURE search_release_tag_update();
 
 CREATE TRIGGER search_release_tag_delete BEFORE DELETE ON musicbrainz.release_tag
     FOR EACH ROW EXECUTE PROCEDURE search_release_tag_delete();
@@ -699,7 +853,9 @@ CREATE TRIGGER search_release_group_alias_insert AFTER INSERT ON musicbrainz.rel
     FOR EACH ROW EXECUTE PROCEDURE search_release_group_alias_insert();
 
 CREATE TRIGGER search_release_group_alias_update AFTER UPDATE OF name, release_group, type ON musicbrainz.release_group_alias
-    FOR EACH ROW EXECUTE PROCEDURE search_release_group_alias_update();
+    FOR EACH ROW
+    WHEN ((OLD.name, OLD.release_group, OLD.type) IS DISTINCT FROM (NEW.name, NEW.release_group, NEW.type))
+    EXECUTE PROCEDURE search_release_group_alias_update();
 
 CREATE TRIGGER search_release_group_alias_delete BEFORE DELETE ON musicbrainz.release_group_alias
     FOR EACH ROW EXECUTE PROCEDURE search_release_group_alias_delete();
@@ -708,7 +864,9 @@ CREATE TRIGGER search_release_group_meta_insert AFTER INSERT ON musicbrainz.rele
     FOR EACH ROW EXECUTE PROCEDURE search_release_group_meta_insert();
 
 CREATE TRIGGER search_release_group_meta_update AFTER UPDATE OF first_release_date_day, first_release_date_month, first_release_date_year, id ON musicbrainz.release_group_meta
-    FOR EACH ROW EXECUTE PROCEDURE search_release_group_meta_update();
+    FOR EACH ROW
+    WHEN ((OLD.first_release_date_day, OLD.first_release_date_month, OLD.first_release_date_year, OLD.id) IS DISTINCT FROM (NEW.first_release_date_day, NEW.first_release_date_month, NEW.first_release_date_year, NEW.id))
+    EXECUTE PROCEDURE search_release_group_meta_update();
 
 CREATE TRIGGER search_release_group_meta_delete BEFORE DELETE ON musicbrainz.release_group_meta
     FOR EACH ROW EXECUTE PROCEDURE search_release_group_meta_delete();
@@ -717,7 +875,9 @@ CREATE TRIGGER search_release_group_tag_insert AFTER INSERT ON musicbrainz.relea
     FOR EACH ROW EXECUTE PROCEDURE search_release_group_tag_insert();
 
 CREATE TRIGGER search_release_group_tag_update AFTER UPDATE OF count, release_group, tag ON musicbrainz.release_group_tag
-    FOR EACH ROW EXECUTE PROCEDURE search_release_group_tag_update();
+    FOR EACH ROW
+    WHEN ((OLD.count, OLD.release_group, OLD.tag) IS DISTINCT FROM (NEW.count, NEW.release_group, NEW.tag))
+    EXECUTE PROCEDURE search_release_group_tag_update();
 
 CREATE TRIGGER search_release_group_tag_delete BEFORE DELETE ON musicbrainz.release_group_tag
     FOR EACH ROW EXECUTE PROCEDURE search_release_group_tag_delete();
@@ -726,7 +886,9 @@ CREATE TRIGGER search_series_alias_insert AFTER INSERT ON musicbrainz.series_ali
     FOR EACH ROW EXECUTE PROCEDURE search_series_alias_insert();
 
 CREATE TRIGGER search_series_alias_update AFTER UPDATE OF begin_date_day, begin_date_month, begin_date_year, end_date_day, end_date_month, end_date_year, locale, name, primary_for_locale, series, sort_name, type ON musicbrainz.series_alias
-    FOR EACH ROW EXECUTE PROCEDURE search_series_alias_update();
+    FOR EACH ROW
+    WHEN ((OLD.begin_date_day, OLD.begin_date_month, OLD.begin_date_year, OLD.end_date_day, OLD.end_date_month, OLD.end_date_year, OLD.locale, OLD.name, OLD.primary_for_locale, OLD.series, OLD.sort_name, OLD.type) IS DISTINCT FROM (NEW.begin_date_day, NEW.begin_date_month, NEW.begin_date_year, NEW.end_date_day, NEW.end_date_month, NEW.end_date_year, NEW.locale, NEW.name, NEW.primary_for_locale, NEW.series, NEW.sort_name, NEW.type))
+    EXECUTE PROCEDURE search_series_alias_update();
 
 CREATE TRIGGER search_series_alias_delete BEFORE DELETE ON musicbrainz.series_alias
     FOR EACH ROW EXECUTE PROCEDURE search_series_alias_delete();
@@ -735,7 +897,9 @@ CREATE TRIGGER search_series_tag_insert AFTER INSERT ON musicbrainz.series_tag
     FOR EACH ROW EXECUTE PROCEDURE search_series_tag_insert();
 
 CREATE TRIGGER search_series_tag_update AFTER UPDATE OF count, series, tag ON musicbrainz.series_tag
-    FOR EACH ROW EXECUTE PROCEDURE search_series_tag_update();
+    FOR EACH ROW
+    WHEN ((OLD.count, OLD.series, OLD.tag) IS DISTINCT FROM (NEW.count, NEW.series, NEW.tag))
+    EXECUTE PROCEDURE search_series_tag_update();
 
 CREATE TRIGGER search_series_tag_delete BEFORE DELETE ON musicbrainz.series_tag
     FOR EACH ROW EXECUTE PROCEDURE search_series_tag_delete();
@@ -744,7 +908,9 @@ CREATE TRIGGER search_series_type_insert AFTER INSERT ON musicbrainz.series_type
     FOR EACH ROW EXECUTE PROCEDURE search_series_type_insert();
 
 CREATE TRIGGER search_series_type_update AFTER UPDATE OF gid, name ON musicbrainz.series_type
-    FOR EACH ROW EXECUTE PROCEDURE search_series_type_update();
+    FOR EACH ROW
+    WHEN ((OLD.gid, OLD.name) IS DISTINCT FROM (NEW.gid, NEW.name))
+    EXECUTE PROCEDURE search_series_type_update();
 
 CREATE TRIGGER search_series_type_delete BEFORE DELETE ON musicbrainz.series_type
     FOR EACH ROW EXECUTE PROCEDURE search_series_type_delete();
@@ -753,7 +919,9 @@ CREATE TRIGGER search_url_insert AFTER INSERT ON musicbrainz.url
     FOR EACH ROW EXECUTE PROCEDURE search_url_insert();
 
 CREATE TRIGGER search_url_update AFTER UPDATE OF gid, url ON musicbrainz.url
-    FOR EACH ROW EXECUTE PROCEDURE search_url_update();
+    FOR EACH ROW
+    WHEN ((OLD.gid, OLD.url) IS DISTINCT FROM (NEW.gid, NEW.url))
+    EXECUTE PROCEDURE search_url_update();
 
 CREATE TRIGGER search_url_delete BEFORE DELETE ON musicbrainz.url
     FOR EACH ROW EXECUTE PROCEDURE search_url_delete();
@@ -762,7 +930,9 @@ CREATE TRIGGER search_l_artist_url_insert AFTER INSERT ON musicbrainz.l_artist_u
     FOR EACH ROW EXECUTE PROCEDURE search_l_artist_url_insert();
 
 CREATE TRIGGER search_l_artist_url_update AFTER UPDATE OF entity0, entity1, link ON musicbrainz.l_artist_url
-    FOR EACH ROW EXECUTE PROCEDURE search_l_artist_url_update();
+    FOR EACH ROW
+    WHEN ((OLD.entity0, OLD.entity1, OLD.link) IS DISTINCT FROM (NEW.entity0, NEW.entity1, NEW.link))
+    EXECUTE PROCEDURE search_l_artist_url_update();
 
 CREATE TRIGGER search_l_artist_url_delete BEFORE DELETE ON musicbrainz.l_artist_url
     FOR EACH ROW EXECUTE PROCEDURE search_l_artist_url_delete();
@@ -771,7 +941,9 @@ CREATE TRIGGER search_link_insert AFTER INSERT ON musicbrainz.link
     FOR EACH ROW EXECUTE PROCEDURE search_link_insert();
 
 CREATE TRIGGER search_link_update AFTER UPDATE OF link_type ON musicbrainz.link
-    FOR EACH ROW EXECUTE PROCEDURE search_link_update();
+    FOR EACH ROW
+    WHEN ((OLD.link_type) IS DISTINCT FROM (NEW.link_type))
+    EXECUTE PROCEDURE search_link_update();
 
 CREATE TRIGGER search_link_delete BEFORE DELETE ON musicbrainz.link
     FOR EACH ROW EXECUTE PROCEDURE search_link_delete();
@@ -780,7 +952,9 @@ CREATE TRIGGER search_link_type_insert AFTER INSERT ON musicbrainz.link_type
     FOR EACH ROW EXECUTE PROCEDURE search_link_type_insert();
 
 CREATE TRIGGER search_link_type_update AFTER UPDATE OF gid, name ON musicbrainz.link_type
-    FOR EACH ROW EXECUTE PROCEDURE search_link_type_update();
+    FOR EACH ROW
+    WHEN ((OLD.gid, OLD.name) IS DISTINCT FROM (NEW.gid, NEW.name))
+    EXECUTE PROCEDURE search_link_type_update();
 
 CREATE TRIGGER search_link_type_delete BEFORE DELETE ON musicbrainz.link_type
     FOR EACH ROW EXECUTE PROCEDURE search_link_type_delete();
@@ -789,7 +963,9 @@ CREATE TRIGGER search_l_release_url_insert AFTER INSERT ON musicbrainz.l_release
     FOR EACH ROW EXECUTE PROCEDURE search_l_release_url_insert();
 
 CREATE TRIGGER search_l_release_url_update AFTER UPDATE OF entity0, entity1, link ON musicbrainz.l_release_url
-    FOR EACH ROW EXECUTE PROCEDURE search_l_release_url_update();
+    FOR EACH ROW
+    WHEN ((OLD.entity0, OLD.entity1, OLD.link) IS DISTINCT FROM (NEW.entity0, NEW.entity1, NEW.link))
+    EXECUTE PROCEDURE search_l_release_url_update();
 
 CREATE TRIGGER search_l_release_url_delete BEFORE DELETE ON musicbrainz.l_release_url
     FOR EACH ROW EXECUTE PROCEDURE search_l_release_url_delete();
@@ -798,7 +974,9 @@ CREATE TRIGGER search_work_alias_insert AFTER INSERT ON musicbrainz.work_alias
     FOR EACH ROW EXECUTE PROCEDURE search_work_alias_insert();
 
 CREATE TRIGGER search_work_alias_update AFTER UPDATE OF begin_date_day, begin_date_month, begin_date_year, end_date_day, end_date_month, end_date_year, locale, name, primary_for_locale, sort_name, type, work ON musicbrainz.work_alias
-    FOR EACH ROW EXECUTE PROCEDURE search_work_alias_update();
+    FOR EACH ROW
+    WHEN ((OLD.begin_date_day, OLD.begin_date_month, OLD.begin_date_year, OLD.end_date_day, OLD.end_date_month, OLD.end_date_year, OLD.locale, OLD.name, OLD.primary_for_locale, OLD.sort_name, OLD.type, OLD.work) IS DISTINCT FROM (NEW.begin_date_day, NEW.begin_date_month, NEW.begin_date_year, NEW.end_date_day, NEW.end_date_month, NEW.end_date_year, NEW.locale, NEW.name, NEW.primary_for_locale, NEW.sort_name, NEW.type, NEW.work))
+    EXECUTE PROCEDURE search_work_alias_update();
 
 CREATE TRIGGER search_work_alias_delete BEFORE DELETE ON musicbrainz.work_alias
     FOR EACH ROW EXECUTE PROCEDURE search_work_alias_delete();
@@ -807,7 +985,9 @@ CREATE TRIGGER search_l_artist_work_insert AFTER INSERT ON musicbrainz.l_artist_
     FOR EACH ROW EXECUTE PROCEDURE search_l_artist_work_insert();
 
 CREATE TRIGGER search_l_artist_work_update AFTER UPDATE OF entity0, entity1, link ON musicbrainz.l_artist_work
-    FOR EACH ROW EXECUTE PROCEDURE search_l_artist_work_update();
+    FOR EACH ROW
+    WHEN ((OLD.entity0, OLD.entity1, OLD.link) IS DISTINCT FROM (NEW.entity0, NEW.entity1, NEW.link))
+    EXECUTE PROCEDURE search_l_artist_work_update();
 
 CREATE TRIGGER search_l_artist_work_delete BEFORE DELETE ON musicbrainz.l_artist_work
     FOR EACH ROW EXECUTE PROCEDURE search_l_artist_work_delete();
@@ -816,7 +996,9 @@ CREATE TRIGGER search_iswc_insert AFTER INSERT ON musicbrainz.iswc
     FOR EACH ROW EXECUTE PROCEDURE search_iswc_insert();
 
 CREATE TRIGGER search_iswc_update AFTER UPDATE OF iswc, work ON musicbrainz.iswc
-    FOR EACH ROW EXECUTE PROCEDURE search_iswc_update();
+    FOR EACH ROW
+    WHEN ((OLD.iswc, OLD.work) IS DISTINCT FROM (NEW.iswc, NEW.work))
+    EXECUTE PROCEDURE search_iswc_update();
 
 CREATE TRIGGER search_iswc_delete BEFORE DELETE ON musicbrainz.iswc
     FOR EACH ROW EXECUTE PROCEDURE search_iswc_delete();
@@ -825,7 +1007,9 @@ CREATE TRIGGER search_work_language_insert AFTER INSERT ON musicbrainz.work_lang
     FOR EACH ROW EXECUTE PROCEDURE search_work_language_insert();
 
 CREATE TRIGGER search_work_language_update AFTER UPDATE OF language, work ON musicbrainz.work_language
-    FOR EACH ROW EXECUTE PROCEDURE search_work_language_update();
+    FOR EACH ROW
+    WHEN ((OLD.language, OLD.work) IS DISTINCT FROM (NEW.language, NEW.work))
+    EXECUTE PROCEDURE search_work_language_update();
 
 CREATE TRIGGER search_work_language_delete BEFORE DELETE ON musicbrainz.work_language
     FOR EACH ROW EXECUTE PROCEDURE search_work_language_delete();
@@ -834,7 +1018,9 @@ CREATE TRIGGER search_l_recording_work_insert AFTER INSERT ON musicbrainz.l_reco
     FOR EACH ROW EXECUTE PROCEDURE search_l_recording_work_insert();
 
 CREATE TRIGGER search_l_recording_work_update AFTER UPDATE OF entity0, entity1, link ON musicbrainz.l_recording_work
-    FOR EACH ROW EXECUTE PROCEDURE search_l_recording_work_update();
+    FOR EACH ROW
+    WHEN ((OLD.entity0, OLD.entity1, OLD.link) IS DISTINCT FROM (NEW.entity0, NEW.entity1, NEW.link))
+    EXECUTE PROCEDURE search_l_recording_work_update();
 
 CREATE TRIGGER search_l_recording_work_delete BEFORE DELETE ON musicbrainz.l_recording_work
     FOR EACH ROW EXECUTE PROCEDURE search_l_recording_work_delete();
@@ -843,7 +1029,9 @@ CREATE TRIGGER search_work_tag_insert AFTER INSERT ON musicbrainz.work_tag
     FOR EACH ROW EXECUTE PROCEDURE search_work_tag_insert();
 
 CREATE TRIGGER search_work_tag_update AFTER UPDATE OF count, tag, work ON musicbrainz.work_tag
-    FOR EACH ROW EXECUTE PROCEDURE search_work_tag_update();
+    FOR EACH ROW
+    WHEN ((OLD.count, OLD.tag, OLD.work) IS DISTINCT FROM (NEW.count, NEW.tag, NEW.work))
+    EXECUTE PROCEDURE search_work_tag_update();
 
 CREATE TRIGGER search_work_tag_delete BEFORE DELETE ON musicbrainz.work_tag
     FOR EACH ROW EXECUTE PROCEDURE search_work_tag_delete();
@@ -852,7 +1040,9 @@ CREATE TRIGGER search_work_type_insert AFTER INSERT ON musicbrainz.work_type
     FOR EACH ROW EXECUTE PROCEDURE search_work_type_insert();
 
 CREATE TRIGGER search_work_type_update AFTER UPDATE OF gid, name ON musicbrainz.work_type
-    FOR EACH ROW EXECUTE PROCEDURE search_work_type_update();
+    FOR EACH ROW
+    WHEN ((OLD.gid, OLD.name) IS DISTINCT FROM (NEW.gid, NEW.name))
+    EXECUTE PROCEDURE search_work_type_update();
 
 CREATE TRIGGER search_work_type_delete BEFORE DELETE ON musicbrainz.work_type
     FOR EACH ROW EXECUTE PROCEDURE search_work_type_delete();


### PR DESCRIPTION
# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

SEARCH-609: SIR triggers do not work as intended when running a MusicBrainz Slave instance

On the primary database: Sometimes columns are unnecessarily updated without a change to the value; See MBS-12178; In turn, triggers send unnecessary messages to SIR.

On replicated databases: The replication process update all columns even though only a small number of those actually have a new value. In turn, triggers send unnecessary messages to SIR.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Compare old/new values of columns before sending any message.

The only exception is `place.coordinates` of type `POINT` which isn’t as straightforward to compare as other data types.

Thanks to @ta264 for implementing it and allowing to incorporate it upstream. I just fixed a pair of bugs.

# Checklist for author
<!--
    The tasks you have to do to get your change ready for review. Use this if
    you draft a pull request. Mark done tasks with an [x] as you progress. See
    https://github.blog/2019-02-14-introducing-draft-pull-requests/
-->

* [x] Test with a local development instance
* [x] Test with a `test.musicbrainz.org`
* [x] Test with a fully featured mirror

# Action
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

1. On deployment of the next SIR release in production, update triggers in the database.