### PR TITLE
Update SIR for schema change 2022 q2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 amqp==2.5.2
 backports.functools_lru_cache==1.0.1
 enum34==1.1.6
-git+https://github.com/yvanzo/mbdata.git@v26.0.dev4#egg=mbdata
+git+https://github.com/amCap1712/mbdata.git@bc3fc985c9842396ac7a0a1190072c093213afeb#egg=mbdata
 git+https://github.com/metabrainz/mb-rngpy.git@v-2.20201112.0#egg=mb-rngpy
 psycopg2==2.8.4
 retrying==1.3.3

--- a/sir/schema/modelext.py
+++ b/sir/schema/modelext.py
@@ -95,7 +95,6 @@ class CustomRecording(Recording):
     aliases = relationship("RecordingAlias")
     first_release_date = relationship("RecordingFirstReleaseDate")
     tags = relationship("RecordingTag")
-    tracks = relationship("Track")
 
 
 class CustomReleaseGroup(ReleaseGroup):


### PR DESCRIPTION
To prepare sir for the schema change, we need to update mbdata version which is compatible with the schema change. Also, updated a model in SIR so that its compatible with the new mbdata version.