### PR TITLE
Fix mocking of entity.build_entity_query

### DIFF
--- a/test/test_amqp_handler.py
+++ b/test/test_amqp_handler.py
@@ -115,6 +115,11 @@ class HandlerTest(AmqpTestCase):
 
         self.handler.cores[self.entity_type] = mock.Mock()
 
+        for entity_type, entity in SCHEMA.items():
+            patcher = mock.patch.object(entity, 'build_entity_query')
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
     def test_delete_callback(self):
         entity_gid = u"90d7709d-feba-47e6-a2d1-8770da3c3d9c"
         self.message = Amqp_Message(
@@ -140,7 +145,7 @@ class HandlerTest(AmqpTestCase):
         self.handler = handler.Handler(SCHEMA.keys())
         for entity_type, entity in SCHEMA.items():
             self.handler.cores[entity_type] = mock.Mock()
-            entity.build_entity_query = mock.MagicMock()
+
         self.handler._index_by_fk(parsed_message)
         calls = self.handler.db_session().execute.call_args_list
         self.assertEqual(len(calls), 6)
@@ -174,7 +179,7 @@ class HandlerTest(AmqpTestCase):
         self.handler = handler.Handler(SCHEMA.keys())
         for entity_type, entity in SCHEMA.items():
             self.handler.cores[entity_type] = mock.Mock()
-            entity.build_entity_query = mock.MagicMock()
+
         self.handler._index_by_fk(parsed_message)
         calls = self.handler.db_session().execute.call_args_list
         self.assertEqual(len(calls), 1)
@@ -193,7 +198,7 @@ class HandlerTest(AmqpTestCase):
         self.handler = handler.Handler(SCHEMA.keys())
         for entity_type, entity in SCHEMA.items():
             self.handler.cores[entity_type] = mock.Mock()
-            entity.build_entity_query = mock.MagicMock()
+
         self.handler._index_by_fk(parsed_message)
         calls = self.handler.db_session().execute.call_args_list
         self.assertEqual(len(calls), 1)


### PR DESCRIPTION
The build_entity_query method of all entities is mocked in test_index_by_fk_* tests. These mocks are never reset after the test is over. This makes the mock visible in other tests instead of the actual method, resulting in failure of those. Fix the issue by using mock.patch and cleaning up after test run is over.