### PR TITLE
Fix deprecation warnings in SIR

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,3 @@
 pytest==4.6.9
 pytest-cov==2.8.1
 mock==3.0.5
-pysqlite==2.8.3

--- a/sir/amqp/handler.py
+++ b/sir/amqp/handler.py
@@ -378,7 +378,7 @@ class Handler(object):
         # to update the related entities. For 'one to many' relationships, the related
         # entity would have had an update trigger firing off to unlink the `index_entity`
         # before `index_entity` itself is deleted, so we can ignore those.
-        relevant_rels = dict((r.mapper.mapped_table.name, (list(r.local_columns)[0].name, list(r.remote_side)[0]))
+        relevant_rels = dict((r.mapper.persist_selectable.name, (list(r.local_columns)[0].name, list(r.remote_side)[0]))
                              for r in class_mapper(index_model).mapper.relationships
                              if r.direction.name == 'MANYTOONE')
         for core_name, path in update_map[parsed_message.table_name]:
@@ -398,7 +398,7 @@ class Handler(object):
             related_model, new_path = second_last_model_in_path(entity.model, path)
             related_table_name = ""
             if related_model:
-                related_table_name = class_mapper(related_model).mapped_table.name
+                related_table_name = class_mapper(related_model).persist_selectable.name
             if related_table_name in relevant_rels:
                 with db_session_ctx(self.db_session) as session:
                     select_query = None

--- a/sir/schema/__init__.py
+++ b/sir/schema/__init__.py
@@ -611,10 +611,10 @@ def generate_update_map():
     for core_name, entity in SCHEMA.items():
         # Entity itself:
         # TODO(roman): See if the line below is necessary, if there is a better way to implement this.
-        persist_selectable = class_mapper(entity.model).persist_selectable.name
-        core_map[persist_selectable] = core_name
-        paths[persist_selectable].add((core_name, None))
-        models[persist_selectable] = entity.model
+        table_name = class_mapper(entity.model).persist_selectable.name
+        core_map[table_name] = core_name
+        paths[table_name].add((core_name, None))
+        models[table_name] = entity.model
         # Related tables:
         for path in unique_split_paths([path for field in entity.fields
                                         for path in field.paths if field.trigger] + [path for path in entity.extrapaths or []]):

--- a/sir/schema/__init__.py
+++ b/sir/schema/__init__.py
@@ -611,16 +611,16 @@ def generate_update_map():
     for core_name, entity in SCHEMA.items():
         # Entity itself:
         # TODO(roman): See if the line below is necessary, if there is a better way to implement this.
-        mapped_table = class_mapper(entity.model).mapped_table.name
-        core_map[mapped_table] = core_name
-        paths[mapped_table].add((core_name, None))
-        models[mapped_table] = entity.model
+        persist_selectable = class_mapper(entity.model).persist_selectable.name
+        core_map[persist_selectable] = core_name
+        paths[persist_selectable].add((core_name, None))
+        models[persist_selectable] = entity.model
         # Related tables:
         for path in unique_split_paths([path for field in entity.fields
                                         for path in field.paths if field.trigger] + [path for path in entity.extrapaths or []]):
             model = last_model_in_path(entity.model, path)
             if model is not None:
-                name = class_mapper(model).mapped_table.name
+                name = class_mapper(model).persist_selectable.name
                 paths[name].add((core_name, path))
                 if name not in models:
                     models[name] = model

--- a/sir/trigger_generation/__init__.py
+++ b/sir/trigger_generation/__init__.py
@@ -76,7 +76,7 @@ def get_trigger_tables(entities):
     for entity in [SCHEMA[name] for name in entities]:
         # Entity table itself
         mapped_class = class_mapper(entity.model)
-        tables[mapped_class.mapped_table.name] = {
+        tables[mapped_class.persist_selectable.name] = {
             "model": entity.model,
             "is_direct": True,
             "has_gid": mapped_class.has_property('gid'),
@@ -87,7 +87,7 @@ def get_trigger_tables(entities):
                                              for path in field.paths if field.trigger]):
             model = last_model_in_path(entity.model, path)
             if model is not None:
-                table_name = class_mapper(model).mapped_table.name
+                table_name = class_mapper(model).persist_selectable.name
                 if table_name not in tables:
                     tables[table_name] = {
                         "model": model,
@@ -106,7 +106,7 @@ def write_triggers(trigger_file, function_file, model, is_direct, has_gid, **gen
     """
     # Mapper defines correlation of model class attributes to database table columns
     mapper = class_mapper(model)
-    table_name = mapper.mapped_table.name
+    table_name = mapper.persist_selectable.name
     fk_columns = [list(r.local_columns)[0].name for r in mapper.relationships
                   if r.direction.name == 'MANYTOONE']
     if is_direct:

--- a/sir/util.py
+++ b/sir/util.py
@@ -47,7 +47,10 @@ def engine():
     for key in ["password", "host", "port"]:
         cdict[key] = cget(key)
     cdict["database"] = cget("dbname")
-    return create_engine(URL("postgresql", **cdict), server_side_cursors=False)
+    return create_engine(
+        URL.create("postgresql", **cdict),
+        server_side_cursors=False
+    )
 
 
 def db_session():

--- a/test/models.py
+++ b/test/models.py
@@ -19,7 +19,6 @@ class B(Base):
     foo = Column(Integer)
     c_id = Column('c', Integer, ForeignKey("table_c.id"))
     composite_column = composite(Comp, foo, c_id)
-    c = relationship("C")
 
 
 class C(Base):
@@ -30,4 +29,4 @@ class C(Base):
     __tablename__ = "table_c"
     id = Column(Integer, primary_key=True)
     bar = Column(Integer)
-    bs = relationship("B")
+    bs = relationship("B", backref="c")


### PR DESCRIPTION
After upgrading SIR to SQLAlchemy 1.4, some deprecation warnings came up.

1. SADeprecationWarning: Use .persist_selectable (deprecated since: 1.3) mapped_table class_mapper(entity.model).mapped_table.name
  Fix is straightforward use .persist_selectable instead of .mapped_table as looking at following docs it only seems to have been renamed.
  [.mapped_table](https://docs.sqlalchemy.org/en/12/orm/mapping_api.html?highlight=mapped_table#sqlalchemy.orm.Mapper.mapped_table) in SQLAlchemy 1.2
  [.persist_selectable](https://docs.sqlalchemy.org/en/14/orm/mapping_api.html?highlight=mapped_table#sqlalchemy.orm.Mapper.persist_selectable) in SQLAlchemy 1.4

2. SADeprecationWarning: Calling URL() directly is deprecated and will be disabled in a future release.  The public constructor for URL is now the URL.create() method.
  As the warning says, replace URL() with URL.create()

3. /usr/local/lib/python2.7/site-packages/pysqlite2/dbapi2.py:81: DeprecationWarning: Converters and adapters are deprecated. Please use only supported SQLite types. Any type mapping should happen in layer above this module.
  This warning comes from pysqlite. Python 2.7 does have a sqlite module so getting rid of pysqlite entirely. We only used it for a few tests in  any case.

4. Finally, there's also a SAWarning about overlapping relationships in B and C models which are only used in tests. Add a backref to fix the warning.