### PR TITLE
Fix performance regression in indexing release group

### DIFF
--- a/sir/schema/__init__.py
+++ b/sir/schema/__init__.py
@@ -462,6 +462,7 @@ SearchReleaseGroup = E(modelext.CustomReleaseGroup, [
                 "artist_credit.artists.artist.aliases.primary_for_locale",
                 "artist_credit.artists.artist.aliases.sort_name",
                 "artist_credit.artists.artist.aliases.type.id",
+                "artist_credit.artists.artist.aliases.type.gid",
                 "artist_credit.artists.artist.aliases.type.name",
                 "artist_credit.artists.artist.gid",
                 "artist_credit.artists.artist.sort_name",


### PR DESCRIPTION
convert_release_group used as wscompat converter for release group core calls convert_alias as well which accesses alias.gid so eagerly load it.

Same as #147 but had merged that into the wrong branch.