### PR TITLE
Fix performance regression in release indexing

### DIFF
--- a/sir/schema/__init__.py
+++ b/sir/schema/__init__.py
@@ -416,6 +416,7 @@ SearchRelease = E(modelext.CustomRelease, [
                 "artist_credit.artists.artist.aliases.type.gid",
                 "artist_credit.artists.artist.gid",
                 "artist_credit.artists.artist.sort_name",
+                "artist_credit.artists.artist.comment",
                 "country_dates.country.area.gid",
                 "country_dates.country.area.name",
                 "country_dates.country.area.iso_3166_1_codes.code",

--- a/sir/schema/__init__.py
+++ b/sir/schema/__init__.py
@@ -429,6 +429,7 @@ SearchRelease = E(modelext.CustomRelease, [
                 "release_group.type.gid",
                 "release_group.secondary_types.secondary_type.gid",
                 "status.gid",
+                "packaging.gid",
                 "language.iso_code_3",
                 "tags.count"]
 )


### PR DESCRIPTION
convert_release used as wscompat converter for release core calls convert_artist_simple as well which accesses comment so eagerly load it.

convert_release used as wscompat converter for release core calls convert_release_packaging as well which accesses comment so eagerly load it.