### PR TITLE
Eagerly load area_type related attributes for artist core

### DIFF
--- a/sir/schema/__init__.py
+++ b/sir/schema/__init__.py
@@ -138,7 +138,9 @@ SearchArtist = E(modelext.CustomArtist, [
                 "begin_area.begin_date", "begin_area.end_date",
                 "begin_area.ended", "end_area.begin_date",
                 "end_area.end_date", "end_area.ended",
-                "gender.gid",
+                "gender.gid", "area.type.gid", "area.type.name",
+                "begin_area.type.gid", "begin_area.type.name",
+                "end_area.type.gid", "end_area.type.name",
                 "type.gid"]
 )
 


### PR DESCRIPTION
# Fix performance regression since SEARCH-689

convert_artist calls convert_area_inner on the area that accesses these area.type.name and area.type.gid attributes so eagerly load these for performance.

# Checklist for author
- [x] Update base branch before merging.