### PR TITLE
SEARCH-688 (I): Use raiseload in query loading options

### DIFF
--- a/sir/schema/searchentities.py
+++ b/sir/schema/searchentities.py
@@ -9,7 +9,7 @@ try:
     from xml.etree.cElementTree import tostring
 except ImportError:
     from xml.etree.ElementTree import tostring
-from sqlalchemy.orm import class_mapper, Load
+from sqlalchemy.orm import class_mapper, Load, raiseload
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy.orm.descriptor_props import CompositeProperty
 from sqlalchemy.orm.interfaces import ONETOMANY, MANYTOONE
@@ -229,7 +229,7 @@ class SearchEntity(object):
                         load = defer_everything_but(class_mapper(model),
                                                     load,
                                                     *required_columns)
-                query = query.options(load)
+                query = query.options(load, raiseload("*"))
         if self.extraquery is not None:
             query = self.extraquery(query)
         return query

--- a/sir/wscompat/convert.py
+++ b/sir/wscompat/convert.py
@@ -124,7 +124,7 @@ def convert_iso_3166_3_code_list(obj):
     return l
 
 
-@lru_cache()
+@lru_cache(maxsize=5000)
 def convert_area_inner(obj):
     """
     :type obj: :class:`mbdata.models.Area`
@@ -150,7 +150,7 @@ def convert_area_simple(obj):
     return area
 
 
-@lru_cache()
+@lru_cache(maxsize=5000)
 def convert_area_for_release_event(obj):
     """
     :type obj: :class:`mbdata.models.Area`
@@ -282,7 +282,7 @@ def convert_attribute(obj):
     return attribute
 
 
-@lru_cache()
+@lru_cache(maxsize=5000)
 def convert_artist_simple(obj, include_aliases=True):
     """
     :type obj: :class:`sir.schema.modelext.CustomArtist`


### PR DESCRIPTION
Use [raiseload](https://docs.sqlalchemy.org/en/14/orm/loading_relationships.html#sqlalchemy.orm.raiseload) loading technique in query options to raise an error on accessing attributes that haven't been eagerly loaded. There have been suboptimal SQL queries in sir previously due to missing columns in extrapaths or using hybrid attributes in fields or extrapaths which caused lazy loading. Since the attributes we access in SIR are fixed and remain the same, we should aim for loading all of those eagerly. raiseload will raise an error with a stacktrace to help us fix the issue if a lazy load happens, helping in performance debugging.

# Checklist for author
- [ ] Run a full reindex because the real data indexing data do not capture all possible relationships of data.