### PR TITLE
Eagerly load area attributes in label indexing

### DIFF
--- a/sir/schema/__init__.py
+++ b/sir/schema/__init__.py
@@ -263,6 +263,7 @@ SearchLabel = E(modelext.CustomLabel, [
                 "aliases.locale", "aliases.primary_for_locale",
                 "aliases.begin_date", "aliases.end_date",
                 "area.gid", "area.type.name", "area.type.gid",
+                "area.begin_date", "area.end_date", "area.ended",
                 "tags.count", "type.gid"
                 ]
 )

--- a/test/sql/label.sql
+++ b/test/sql/label.sql
@@ -1,13 +1,14 @@
-INSERT INTO area (id, gid, name, type) VALUES
-  (221, '8a754a16-0027-3a29-b6d7-2b40ea0481ed', 'United Kingdom', 1);
-INSERT INTO country_area (area) VALUES (221);
-INSERT INTO iso_3166_1 (area, code) VALUES (221, 'GB');
+INSERT INTO area (id, gid, name, type, begin_date_year, end_date_year, ended) VALUES
+  (221, '8a754a16-0027-3a29-b6d7-2b40ea0481ed', 'United Kingdom', 1, NULL, NULL, 'f'),
+  (243, '32f90933-b4b4-3248-b98c-e573d5329f57', 'Soviet Union', 1, 1922, 1991, 't');
+INSERT INTO country_area (area) VALUES (221), (243);
+INSERT INTO iso_3166_1 (area, code) VALUES (221, 'GB'), (243, 'SU');
 
 INSERT INTO label (id, gid, name, type, area, label_code,
                    begin_date_year, begin_date_month, begin_date_day,
                    end_date_year, end_date_month, end_date_day, comment)
-     VALUES (3, '46f0f4cd-8aab-4b33-b698-f459faf64190', 'Warp Records', 3, 221, 2070,
-             1989, 02, 03, 2008, 05, 19, 'Sheffield based electronica label');
+     VALUES (3, '46f0f4cd-8aab-4b33-b698-f459faf64190', 'Warp Records', 3, 221, 2070, 1989, 02, 03, 2008, 05, 19, 'Sheffield based electronica label'),
+            (135155, '449ddb7e-4e92-41eb-a683-5bbcc7fd7d4a', 'U.S.S.R. Ministry of Culture', NULL, 243, NULL, 1953, 3, 15, 1991, 11, 27, '');
 
 INSERT INTO label (id, gid, name)
     VALUES (2, 'f2a9a3c0-72e3-11de-8a39-0800200c9a66', 'To Merge');

--- a/test/test_indexing_real_data.py
+++ b/test/test_indexing_real_data.py
@@ -223,7 +223,17 @@ class IndexingTestCase(unittest.TestCase):
                 'mbid': 'f2a9a3c0-72e3-11de-8a39-0800200c9a66',
                 '_store': '<ns0:label xmlns:ns0="http://musicbrainz.org/ns/mmd-2.0#" id="f2a9a3c0-72e3-11de-8a39-0800200c9a66"><ns0:name>To Merge</ns0:name><ns0:sort-name>To Merge</ns0:sort-name><ns0:life-span><ns0:ended>false</ns0:ended></ns0:life-span></ns0:label>',
                 'label': u'To Merge'
-            }
+            },
+            {
+                'begin': '1953-03-15',
+                'end': '1991-11-27',
+                'area': u'Soviet Union',
+                'country': u'SU',
+                'label': u'U.S.S.R. Ministry of Culture',
+                'ended': 'true',
+                'mbid': '449ddb7e-4e92-41eb-a683-5bbcc7fd7d4a',
+                '_store': '<ns0:label xmlns:ns0="http://musicbrainz.org/ns/mmd-2.0#" id="449ddb7e-4e92-41eb-a683-5bbcc7fd7d4a"><ns0:name>U.S.S.R. Ministry of Culture</ns0:name><ns0:sort-name>U.S.S.R. Ministry of Culture</ns0:sort-name><ns0:country>SU</ns0:country><ns0:area id="32f90933-b4b4-3248-b98c-e573d5329f57" type="Country" type-id="06dd0ae4-8c74-30bb-b43d-95dcedf961de"><ns0:name>Soviet Union</ns0:name><ns0:sort-name>Soviet Union</ns0:sort-name><ns0:life-span><ns0:begin>1922</ns0:begin><ns0:end>1991</ns0:end><ns0:ended>true</ns0:ended></ns0:life-span></ns0:area><ns0:life-span><ns0:begin>1953-03-15</ns0:begin><ns0:end>1991-11-27</ns0:end><ns0:ended>true</ns0:ended></ns0:life-span></ns0:label>'
+             }
         ]
         self._test_index_entity("label", expected)
 


### PR DESCRIPTION
convert_label used as wscompat converter for label core calls convert_area_inner as well which accesses area.begin_date, area.end_date, area.ended so eagerly load it.

Also, add one more test case where these fields aren't NULL.