### PR TITLE
Amend 2bbacca6: Declare exchanges/queues on RabbitMQ move

### DIFF
--- a/docs/source/service/rabbitmq.rst
+++ b/docs/source/service/rabbitmq.rst
@@ -65,6 +65,7 @@ Procedures
 * Move service:
 
   * Create vhost, user, permissions, queues in the new instance
+  * Declare exchanges and queues as described in :ref:`amqp`
   * Update broker in PostgreSQL to point to the new instance
   * Once the queues in the old instance are empty,
     switch the live indexer to the new instance


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to Search Index Rebuilder (SIR).
    We appreciate your time and interest in helping our project!

    Please use this template to help us review your change.

    Depending on your change, some sections may be unneeded, just remove these.
    For example, small pull requests usually don’t need the section “Action”.

    Remember that the more helpful info your pull request includes,
    the easier it is for us to understand and review your changes.

    Ensure that you’ve read through and followed the Contributing Guidelines, at
    https://github.com/metabrainz/sir/blob/master/CONTRIBUTING.md
-->

# Problem
<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

When moving to another instance of RabbitMQ (mostly for master not mirror), the exchanges and queues have to be declared using SIR’s `amqp_setup` command, otherwise messages are just dropped by the new RabbitMQ instance. This step was missing in the documentation (currently at <https://sir.readthedocs.io/en/latest/service/index.html#rabbitmq-1>).

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

Add a line about it, amending the (not yet released) pull request #139 for SEARCH-675.