### PR TITLE
SEARCH-740: Upgrade MB DB schema version to 30 - 2025 Q2

### DIFF
--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -10,7 +10,7 @@ services:
       - musicbrainz_db
 
   musicbrainz_db:
-    image: metabrainz/musicbrainz-test-database:production
+    image: metabrainz/musicbrainz-test-database:master
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       PGDATA: /var/lib/postgresql-musicbrainz/data

--- a/docs/source/setup/mbdbschema.rst
+++ b/docs/source/setup/mbdbschema.rst
@@ -2,11 +2,11 @@ MusicBrainz Database Schema
 ----
 
 Of course you'll need a MusicBrainz database somewhere to read the data from.
-The active database schema sequence must be `27` (or any future schema version
+The active database schema sequence must be `30` (or any future schema version
 if still compatible). Follow `announcements`_ from the MetaBrainz blog.
 
-Only Sir `3.y.z` is able to read from database of schema sequence `27`
+Only Sir `4.y.z` is able to read from database of schema sequence `30`
 (or any future schema if still compatible, but it reads and sends the
-data made available from schema sequence `27` only).
+data made available from schema sequence `30` only).
 
 .. _announcements: https://blog.metabrainz.org/category/schema-change-release/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 amqp==5.1.1
 mbdata@git+https://github.com/acoustid/mbdata.git@37d507a54251f96cb7aa71a3ab59c41f357db61e
-mb-rngpy@git+https://github.com/mwiencek/mb-rngpy.git@v-2.20250227.0.dev0
+mb-rngpy==2.20250423.0
 psycopg2-binary==2.9.10
 retrying==1.3.3
 pysolr==3.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 amqp==5.1.1
-mbdata@git+https://github.com/acoustid/mbdata.git@37d507a54251f96cb7aa71a3ab59c41f357db61e
+git+https://github.com/metabrainz/mbdata.git@v30.0.0#egg=mbdata
 mb-rngpy==2.20250423.0
 psycopg2-binary==2.9.10
 retrying==1.3.3


### PR DESCRIPTION
## Changes

- SEARCH-740: This patch makes SIR uses [`mbdata@v30.0.0`](https://github.com/metabrainz/mbdata/releases/tag/v30.0.0) generated from the upcoming MB DB schema 30 -2025 Q2, in:
  * requirements
  * tests
  * docs 
- It also updates the MB XML RELAX NG schema binding version to [`2.20250423.0`](https://pypi.org/project/mb-rngpy/2.20250423.0/) which is used in [MB Solr 4](https://github.com/metabrainz/mb-solr/releases/tag/v4.0.0) too.

## Tests

This has been manually tested on `test.mb.o` by @mwiencek if I understood correctly.