### PR TITLE
Remove unused apt packages from the Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,16 +22,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
                     build-essential \
                     ca-certificates \
-                    cron \
                     curl \
-                    git \
-                    gnupg \
-                    libz-dev \
-                    libpq-dev \
-                    libffi-dev \
-                    libssl-dev \
-                    libxml2-dev \
-                    libxslt1-dev && \
+                    gnupg && \
     rm -rf /var/lib/apt/lists/*
 
 # PostgreSQL client

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -11,16 +11,7 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
                     build-essential \
-                    ca-certificates \
-                    cron \
-                    git \
-                    libz-dev \
-                    libpq-dev \
-                    libffi-dev \
-                    libssl-dev \
-                    libxml2-dev \
-                    libsqlite3-dev \
-                    libxslt1-dev && \
+                    ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 COPY requirements.txt /code/
 COPY requirements_dev.txt /code/


### PR DESCRIPTION
I was able to build the images fine after removing these. I guess everything has a wheel now except for ujson, which only requires build-essential.

There are no crontabs in the repo, so I removed cron. git isn't required either. If these are needed for some one-off sysadmin task in the future, they can always be installed manually.