### PR TITLE
Update requests and urllib3 dependencies

### DIFF
--- a/docs/source/setup/solr.rst
+++ b/docs/source/setup/solr.rst
@@ -19,5 +19,5 @@ Keys                  Description
                       (default is ``1``)
 ===================== ===========
 
-.. _backoff factor: https://urllib3.readthedocs.io/en/2.4.0/reference/urllib3.util.html#urllib3.util.Retry
+.. _backoff factor: https://urllib3.readthedocs.io/en/2.5.0/reference/urllib3.util.html#urllib3.util.Retry
 .. _mbsssss: https://github.com/metabrainz/mbsssss

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ psycopg2-binary==2.9.10
 retrying==1.3.3
 pysolr==3.10.0
 sqlalchemy==2.0.38
-requests==2.32.3
+requests==2.32.4
 ujson==1.35
 sentry-sdk==2.23.1
 sqlalchemy-utils==0.41.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ requests==2.32.3
 ujson==1.35
 sentry-sdk==2.23.1
 sqlalchemy-utils==0.41.1
-urllib3==2.4.0
+urllib3==2.5.0


### PR DESCRIPTION
# Problem

There has been a few security vulnerabilities in `requests` and `urllib3` dependencies resolved by new versions. Even though those vulnerabilities do not affect SIR in its current usage, it is preferable to keep following the latest versions.

# Solution
<!--
    Talk about technical details, considerations, or other interesting points.
-->

* Bump urllib3 required version to 2.5.0
* Bump requests required version to 2.32.4